### PR TITLE
Correcting variable name

### DIFF
--- a/Run/SetupDatabase.ps1
+++ b/Run/SetupDatabase.ps1
@@ -8,7 +8,7 @@
 #     $databaseName
 #
 
-if ($restartInstance) {
+if ($restartingInstance) {
 
     # Nothing to do
 


### PR DESCRIPTION
The wrong variable name caused the following error when stopping and restarting a container:
``` 
PS C:\Windows\system32> docker start -ai mynav
Initializing...
Restarting Instance
Starting Local SQL Server
C:\Run\SetupDatabase.ps1 : ERROR: Internal Error
At C:\Run\navstart.ps1:189 char:5
+     . (Get-MyFilePath "SetupDatabase.ps1")
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorExcep
   tion
    + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorExceptio
   n,SetupDatabase.ps1
```

The right variable name is the one used in `navstart.ps1`