### PR TITLE
ClickOnce shouldn't rely on NAV-DVD

### DIFF
--- a/Run/SetupClickOnce.ps1
+++ b/Run/SetupClickOnce.ps1
@@ -10,14 +10,14 @@
 # OUTPUT
 #
 
-Import-Module "$PowerShellScriptsFolder\NAVAdministration.psm1"
+Import-Module "$NAVAdministrationScriptsFolder\NAVAdministration.psm1"
 Import-Module WebAdministration
 
 $clickOnceDirectory = Join-Path $httpPath "NAV"
 Remove-Item $clickOnceDirectory -Force -Recurse -ErrorAction SilentlyContinue
 $webSiteUrl = "http://${hostname}:$publicFileSharePort/NAV"
 
-$ClientUserSettingsFileName = "C:\ClientUserSettings.config"
+$ClientUserSettingsFileName = "$runPath\ClientUserSettings.config"
 [xml]$ClientUserSettings = Get-Content $clientUserSettingsFileName
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='Server']").value = "$hostname"
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='ServerInstance']").value="NAV"
@@ -26,8 +26,6 @@ $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='Clie
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='ACSUri']").value = ""
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='DnsIdentity']").value = "$dnsIdentity"
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='ClientServicesCredentialType']").value = "$Auth"
-
-$navVersion = Get-ChildItem -Path $roleTailoredClientFolder -Filter finsql.exe | Select-Object -First 1 | ForEach-Object { $_.VersionInfo.ProductVersion }
 
 $applicationName = "NAV Windows Client for $hostname"
 $applicationNameFinSql = "NAV C/SIDE for $hostname"

--- a/Run/SetupClickOnce.ps1
+++ b/Run/SetupClickOnce.ps1
@@ -10,14 +10,14 @@
 # OUTPUT
 #
 
-Import-Module "$navDvdPath\WindowsPowerShellScripts\Cloud\NAVAdministration\NAVAdministration.psm1"
+Import-Module "$PowerShellScriptsFolder\NAVAdministration.psm1"
 Import-Module WebAdministration
 
 $clickOnceDirectory = Join-Path $httpPath "NAV"
 Remove-Item $clickOnceDirectory -Force -Recurse -ErrorAction SilentlyContinue
 $webSiteUrl = "http://${hostname}:$publicFileSharePort/NAV"
 
-$ClientUserSettingsFileName = Join-Path (Get-ChildItem -Path "$NavDvdPath\RoleTailoredClient\CommonAppData\Microsoft\Microsoft Dynamics NAV" -Directory | Select-Object -Last 1).FullName "ClientUserSettings.config"
+$ClientUserSettingsFileName = "C:\ClientUserSettings.config"
 [xml]$ClientUserSettings = Get-Content $clientUserSettingsFileName
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='Server']").value = "$hostname"
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='ServerInstance']").value="NAV"
@@ -27,7 +27,7 @@ $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='ACSU
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='DnsIdentity']").value = "$dnsIdentity"
 $clientUserSettings.SelectSingleNode("//configuration/appSettings/add[@key='ClientServicesCredentialType']").value = "$Auth"
 
-$navVersion = Get-ChildItem -Path $NavDvdPath -Filter setup.exe | Select-Object -First 1 | ForEach-Object { $_.VersionInfo.ProductVersion }
+$navVersion = Get-ChildItem -Path $roleTailoredClientFolder -Filter finsql.exe | Select-Object -First 1 | ForEach-Object { $_.VersionInfo.ProductVersion }
 
 $applicationName = "NAV Windows Client for $hostname"
 $applicationNameFinSql = "NAV C/SIDE for $hostname"

--- a/Run/navstart.ps1
+++ b/Run/navstart.ps1
@@ -152,12 +152,19 @@ if ($runningGenericImage -or $buildingImage) {
     Copy-Item -Path "$navDvdPath\RoleTailoredClient\program files\Microsoft Dynamics NAV" -Destination "C:\Program Files (x86)\" -Recurse -Force
     Copy-Item -Path "$navDvdPath\ClickOnceInstallerTools\Program Files\Microsoft Dynamics NAV" -Destination "C:\Program Files (x86)\" -Recurse -Force
     Copy-Item -Path "$navDvdPath\*.vsix" -Destination $runPath
+
+    Write-Host "Copy PowerShell Scripts"
+    Copy-Item -Path "$navDvdPath\WindowsPowerShellScripts\Cloud\NAVAdministration\" -Destination "C:\Program Files (x86)\" -Recurse -Force
+
+    Write-Host "Copy ClientUserSettings"
+    Copy-Item (Join-Path (Get-ChildItem -Path "$NavDvdPath\RoleTailoredClient\CommonAppData\Microsoft\Microsoft Dynamics NAV" -Directory | Select-Object -Last 1).FullName "ClientUserSettings.config") "C:\"
 }
 
 $serviceTierFolder = (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service").FullName
 $roleTailoredClientFolder = (Get-Item "C:\Program Files (x86)\Microsoft Dynamics NAV\*\RoleTailored Client").FullName
 $clickOnceInstallerToolsFolder = (Get-Item "C:\Program Files (x86)\Microsoft Dynamics NAV\*\ClickOnce Installer Tools").FullName
 $WebClientFolder = (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Web Client")[0]
+$PowerShellScriptsFolder = (Get-Item "C:\Program Files (x86)\NAVAdministration").FullName
 
 if (!(Test-Path (Join-Path $roleTailoredClientFolder 'hlink.dll'))) {
     Copy-Item -Path (Join-Path $runPath 'Install\hlink.dll') -Destination (Join-Path $roleTailoredClientFolder 'hlink.dll')

--- a/Run/navstart.ps1
+++ b/Run/navstart.ps1
@@ -154,17 +154,17 @@ if ($runningGenericImage -or $buildingImage) {
     Copy-Item -Path "$navDvdPath\*.vsix" -Destination $runPath
 
     Write-Host "Copy PowerShell Scripts"
-    Copy-Item -Path "$navDvdPath\WindowsPowerShellScripts\Cloud\NAVAdministration\" -Destination "C:\Program Files (x86)\" -Recurse -Force
+    Copy-Item -Path "$navDvdPath\WindowsPowerShellScripts\Cloud\NAVAdministration\" -Destination $runPath -Recurse -Force
 
     Write-Host "Copy ClientUserSettings"
-    Copy-Item (Join-Path (Get-ChildItem -Path "$NavDvdPath\RoleTailoredClient\CommonAppData\Microsoft\Microsoft Dynamics NAV" -Directory | Select-Object -Last 1).FullName "ClientUserSettings.config") "C:\"
+    Copy-Item (Join-Path (Get-ChildItem -Path "$NavDvdPath\RoleTailoredClient\CommonAppData\Microsoft\Microsoft Dynamics NAV" -Directory | Select-Object -Last 1).FullName "ClientUserSettings.config") $runPath
 }
 
 $serviceTierFolder = (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service").FullName
 $roleTailoredClientFolder = (Get-Item "C:\Program Files (x86)\Microsoft Dynamics NAV\*\RoleTailored Client").FullName
 $clickOnceInstallerToolsFolder = (Get-Item "C:\Program Files (x86)\Microsoft Dynamics NAV\*\ClickOnce Installer Tools").FullName
 $WebClientFolder = (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Web Client")[0]
-$PowerShellScriptsFolder = (Get-Item "C:\Program Files (x86)\NAVAdministration").FullName
+$NAVAdministrationScriptsFolder = (Get-Item "$runPath\NAVAdministration").FullName
 
 if (!(Test-Path (Join-Path $roleTailoredClientFolder 'hlink.dll'))) {
     Copy-Item -Path (Join-Path $runPath 'Install\hlink.dll') -Destination (Join-Path $roleTailoredClientFolder 'hlink.dll')


### PR DESCRIPTION
As ClickOnce manifest is recreated when running specific image (see first and last line): 
https://github.com/Microsoft/nav-docker/blob/65656bdbc8845e6c2dc7d0aaca56842fabdd6911/Run/navstart.ps1#L251-L351

without NAV-DVD mounted it shouldn't rely on the NAV-DVD. Therefore the needed scripts and the ClientUserSettings should be copied to the file system as well.

We could also remove `$navVersion` variable as it is currently not used anywhere?