### PR TITLE
Own DB when building specific image

### DIFF
--- a/Run/navstart.ps1
+++ b/Run/navstart.ps1
@@ -181,7 +181,7 @@ if (!(Test-Path (Join-Path $serviceTierFolder 'hlink.dll'))) {
 Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Management.psm1"
 
 # Database
-if ($buildingImage) {
+if ($buildingImage -and ($bakfile -eq "")) {
 
     # Restore CRONUS Demo database to databases folder
 


### PR DESCRIPTION
This allows to specify a BAK file during build of a specific image which is then restored instead of the CRONUS database. This saves some space and time (took me only around 1.5min for a upstart of the generated image!) compared to restoring a database next to the CRONUS database while `docker run`.

A Dockerfile for building the specific image with specific database and license could then look like this:
```
FROM mygenericimage

ENV NAVDVDURL http://navfileserver/mydvd.zip
ENV licensefile http://navfileserver/mylicense.flf
ENV bakfile http://navfileserver/mydb.bak

RUN PowerShell .\Run\buildimage.ps1
ENV DatabaseServer localhost
ENV DatabaseName mydatabase

ENV licensefile ''
ENV bakfile ''
```

Note that we have to reset `licensefile` and `bakfile` environment variables after calling the buildscript to prevent restoring the database and license again at `docker run`. 
I tried removing the environment variables via `Remove-Item ENV:\licensefile` in the buildscript. It worked, but docker seems to recreate them when doing a `docker run`. Any other ideas appreciated! As the original intention is to use the official images only I think this shouldn't be a big problem for those who want to build specific images themselves.
