### PR TITLE
Fix in SetupSqlUsers.ps1 to use database instance when needed.

### DIFF
--- a/Run/SetupSqlUsers.ps1
+++ b/Run/SetupSqlUsers.ps1
@@ -10,7 +10,13 @@
 if ($databaseServer -eq "localhost") {
     if ($password -ne "") {
         $sqlcmd = "ALTER LOGIN sa with password=" +"'" + $password + "'" + ",CHECK_POLICY = OFF;ALTER LOGIN sa ENABLE;"
-        & sqlcmd -Q $sqlcmd
+
+        if ($databaseInstance) {
+            & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
+        } else {
+            & sqlcmd -S $databaseServer -Q $sqlcmd
+        }
+
     }
     
     if ($username.Contains('\') -and $auth -eq "Windows") {
@@ -27,6 +33,10 @@ if ($databaseServer -eq "localhost") {
             ALTER LOGIN [$username] ENABLE
             GO"
             
-        & sqlcmd -Q $sqlcmd
+            if ($databaseInstance) {
+                & sqlcmd -S "$databaseServer\$databaseInstance" -Q $sqlcmd
+            } else {
+                & sqlcmd -S $databaseServer -Q $sqlcmd
+            }
     }
 }

--- a/Run/navstart.ps1
+++ b/Run/navstart.ps1
@@ -373,8 +373,8 @@ if ($runningGenericImage -or $runningSpecificImage) {
         . (Get-MyFilePath "SetupFileShare.ps1")
     }
 
-    . (Get-MyFilePath "SetupSqlUsers.ps1")
     . (Get-MyFilePath "SetupNavUsers.ps1")
+    . (Get-MyFilePath "SetupSqlUsers.ps1")
     . (Get-MyFilePath "AdditionalSetup.ps1")
 }
 


### PR DESCRIPTION
Fix in SetupSqlUsers.ps1 to use database instance when needed.

Fix in navstart.ps1 to first call SetupNavUser because this script generates the password if not specified. Password is needed in SetupSqlUsers.