### PR TITLE
Secure password fix

### DIFF
--- a/Run/SetupVariables.ps1
+++ b/Run/SetupVariables.ps1
@@ -24,7 +24,7 @@ if ("$env:password" -ne "") {
     $securepassword = ConvertTo-SecureString -String "$env:password" -AsPlainText -Force
     Remove-Item env:\password -ErrorAction Ignore
     $passwordSpecified = $true
-} elseif ("$env:securepassword" -ne "" -and "$env:passwordKeyFile" -ne "") {
+} elseif ("$env:securepassword" -ne "" -and "$env:passwordKeyFile" -ne "" -and $restartingInstance -eq $false) {
     $securePassword = ConvertTo-SecureString -String "$env:securepassword" -Key (Get-Content -Path "$env:passwordKeyFile")
     if ($env:RemovePasswordKeyFile -ne "N") {
         Remove-Item -Path "$env:passwordKeyFile" -Force

--- a/Run/navstart.ps1
+++ b/Run/navstart.ps1
@@ -4,6 +4,10 @@ $runPath = "c:\Run"
 $myPath = Join-Path $runPath "my"
 $navDvdPath = "C:\NAVDVD"
 
+$publicDnsNameFile = "$RunPath\PublicDnsName.txt"
+$publicDnsNameChanged = $false
+$restartingInstance = Test-Path -Path $publicDnsNameFile -PathType Leaf
+
 function Get-MyFilePath([string]$FileName)
 {
     if ((Test-Path $myPath -PathType Container) -and (Test-Path (Join-Path $myPath $FileName) -PathType Leaf)) {
@@ -77,9 +81,6 @@ if ($publicODataPort     -eq "") { $publicODataPort     = "7048" }
 
 if ($buildingImage) { Write-Host "Building Image" }
 
-$publicDnsNameFile = "$RunPath\PublicDnsName.txt"
-$publicDnsNameChanged = $false
-$restartingInstance = Test-Path -Path $publicDnsNameFile -PathType Leaf
 if ($restartingInstance) {
     Write-Host "Restarting Instance"
     $prevPublicDnsName = Get-Content -Path $publicDnsNameFile
@@ -433,4 +434,6 @@ Microsoft recommends that you always run the latest version of our containers."
 
     Write-Host "Ready for connections!"
 }
-Clear-Variable -Name "securePassword"
+if ("$securepassword") {
+    Clear-Variable -Name "securePassword"
+}


### PR DESCRIPTION
Fix for #91 

Avoid using secure password when restarting container.

I have done some rapid test (build my own image on top of your one as the affected code is related to the runtime parts of the code; I have overwritten all files in `c:\run` with my version; I think the test should be consistent).

Both, `docker run` and `docker start` (`docker restart`) work correctly.