### PR TITLE
Enable Symbol Loading At Server Startup

### DIFF
--- a/Run/SetupConfiguration.ps1
+++ b/Run/SetupConfiguration.ps1
@@ -34,6 +34,10 @@ if ($developerServicesKeyExists) {
     $customConfig.SelectSingleNode("//appSettings/add[@key='DeveloperServicesEnabled']").Value = "true"
     $CustomConfig.SelectSingleNode("//appSettings/add[@key='DeveloperServicesSSLEnabled']").Value = $servicesUseSSL.ToString().ToLower()
 }
+$enableSymbolLoadingAtServerStartupKeyExists = ($customConfig.SelectSingleNode("//appSettings/add[@key='EnableSymbolLoadingAtServerStartup']") -ne $null)
+if ($enableSymbolLoadingAtServerStartupKeyExists) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='EnableSymbolLoadingAtServerStartup']").Value = "$($enableSymbolLoadingAtServerStartup -eq $true)"
+}
 $CustomConfig.Save($CustomConfigFile)
 
 7045,7047,7048,7049 | % {

--- a/Run/SetupVariables.ps1
+++ b/Run/SetupVariables.ps1
@@ -78,3 +78,7 @@ if ($locale)  {
     Set-WinSystemLocale -SystemLocale $cultureInfo
     Set-Culture -CultureInfo $cultureInfo
 }
+
+if ($env:symbolLoading -eq "Y") {
+    $enableSymbolLoadingAtServerStartup = $true
+}

--- a/Run/SetupVariables.ps1
+++ b/Run/SetupVariables.ps1
@@ -79,6 +79,4 @@ if ($locale)  {
     Set-Culture -CultureInfo $cultureInfo
 }
 
-if ($env:symbolLoading -eq "Y") {
-    $enableSymbolLoadingAtServerStartup = $true
-}
+$enableSymbolLoadingAtServerStartup = ($env:enableSymbolLoading -eq "Y")


### PR DESCRIPTION
Enable Symbol Loading At Server Startup can be activated like this:
```
-e symbolLoading=Y `
```

Tested with:
+ November update (with the flag/without the flag)
+ The latest 2017 CU (with the flag/without the flag)
Everything was working as expected (the configuration was active/wasn\`t active) and no side effects have been seen.