### PR TITLE
Allow arbitrary config settings through params and download of "my"-scripts

### DIFF
--- a/Run/SetupConfiguration.ps1
+++ b/Run/SetupConfiguration.ps1
@@ -53,6 +53,18 @@ $enableSymbolLoadingAtServerStartupKeyExists = ($customConfig.SelectSingleNode("
 if ($enableSymbolLoadingAtServerStartupKeyExists) {
     $customConfig.SelectSingleNode("//appSettings/add[@key='EnableSymbolLoadingAtServerStartup']").Value = "$($enableSymbolLoadingAtServerStartup -eq $true)"
 }
+
+if ($customNavSettings -ne "") {
+    $customNavSettingsArray = $customNavSettings -split ","
+    foreach ($customNavSetting in $customNavSettingsArray) {
+        $customNavSettingArray = $customNavSetting -split "="
+        $customNavSettingKey = $customNavSettingArray[0]
+        $customNavSettingValue = $customNavSettingArray[1]
+        Write-Host "setting $customNavSettingKey to $customNavSettingValue"
+        $customConfig.SelectSingleNode("//appSettings/add[@key='$customNavSettingKey']").Value = "$customNavSettingValue"
+    }
+}
+
 $CustomConfig.Save($CustomConfigFile)
 
 7045,7047,7048,7049 | % {

--- a/Run/SetupConfiguration.ps1
+++ b/Run/SetupConfiguration.ps1
@@ -53,18 +53,6 @@ $enableSymbolLoadingAtServerStartupKeyExists = ($customConfig.SelectSingleNode("
 if ($enableSymbolLoadingAtServerStartupKeyExists) {
     $customConfig.SelectSingleNode("//appSettings/add[@key='EnableSymbolLoadingAtServerStartup']").Value = "$($enableSymbolLoadingAtServerStartup -eq $true)"
 }
-
-if ($customNavSettings -ne "") {
-    $customNavSettingsArray = $customNavSettings -split ","
-    foreach ($customNavSetting in $customNavSettingsArray) {
-        $customNavSettingArray = $customNavSetting -split "="
-        $customNavSettingKey = $customNavSettingArray[0]
-        $customNavSettingValue = $customNavSettingArray[1]
-        Write-Host "setting $customNavSettingKey to $customNavSettingValue"
-        $customConfig.SelectSingleNode("//appSettings/add[@key='$customNavSettingKey']").Value = "$customNavSettingValue"
-    }
-}
-
 $CustomConfig.Save($CustomConfigFile)
 
 7045,7047,7048,7049 | % {

--- a/Run/SetupVariables.ps1
+++ b/Run/SetupVariables.ps1
@@ -134,3 +134,7 @@ if ($locale)  {
 }
 
 $enableSymbolLoadingAtServerStartup = ($env:enableSymbolLoading -eq "Y")
+
+$myFilesPackage = "$env:myFilesPackage"
+
+$customNavSettings = "$env:customNavSettings"

--- a/Run/SetupVariables.ps1
+++ b/Run/SetupVariables.ps1
@@ -135,6 +135,6 @@ if ($locale)  {
 
 $enableSymbolLoadingAtServerStartup = ($env:enableSymbolLoading -eq "Y")
 
-$myFilesPackage = "$env:myFilesPackage"
+$folders = "$env:folders"
 
 $customNavSettings = "$env:customNavSettings"

--- a/Run/SetupVariables.ps1
+++ b/Run/SetupVariables.ps1
@@ -136,5 +136,3 @@ if ($locale)  {
 $enableSymbolLoadingAtServerStartup = ($env:enableSymbolLoading -eq "Y")
 
 $folders = "$env:folders"
-
-$customNavSettings = "$env:customNavSettings"

--- a/Run/navstart.ps1
+++ b/Run/navstart.ps1
@@ -22,6 +22,13 @@ $hostname = hostname
 . (Get-MyFilePath "HelperFunctions.ps1")
 . (Get-MyFilePath "SetupVariables.ps1")
 
+if (-not (Test-Path $myPath -PathType Container) -and ($myFilesPackage -ne "")) {
+    $myFilesPackageFile = (Join-Path $runPath "myFilesPackage.zip")
+    Write-Host "Downloading package for c:\run\my files '$myFilesPackage'"
+    (New-Object System.Net.WebClient).DownloadFile($myFilesPackage, $myFilesPackageFile)
+    Expand-Archive $myFilesPackageFile -DestinationPath $runPath
+}
+
 $newPublicDnsName = $true
 if ($restartingInstance) {
     Write-Host "Restarting Container"

--- a/Run/navstart.ps1
+++ b/Run/navstart.ps1
@@ -22,11 +22,19 @@ $hostname = hostname
 . (Get-MyFilePath "HelperFunctions.ps1")
 . (Get-MyFilePath "SetupVariables.ps1")
 
-if (-not (Test-Path $myPath -PathType Container) -and ($myFilesPackage -ne "")) {
-    $myFilesPackageFile = (Join-Path $runPath "myFilesPackage.zip")
-    Write-Host "Downloading package for c:\run\my files '$myFilesPackage'"
-    (New-Object System.Net.WebClient).DownloadFile($myFilesPackage, $myFilesPackageFile)
-    Expand-Archive $myFilesPackageFile -DestinationPath $runPath
+if ($folders -ne "") {
+    $foldersArray = $folders -split ","
+    foreach ($folder in $foldersArray) {
+        $keyValue = $folder -split "="
+        $key = $keyValue[0]
+        $value = $keyValue[1]
+        Write-Host "folder $key gets data from $value"
+        if (-not (Test-Path $key)) {
+            New-Item $key -ItemType Directory
+        }
+        (New-Object System.Net.WebClient).DownloadFile($value, "download.zip")
+        Expand-Archive "download.zip" -DestinationPath $key
+    }
 }
 
 $newPublicDnsName = $true


### PR DESCRIPTION
I think it should be possible to change arbitrary config settings for the NAV Server instance without having to script anything. And in serverless scenarios like Azure Container instances it would also be nice to be able to somehow get custom scripts into the container without having to map a volume. Therefore this PR proposes two additions:

1. A new env param customNavSettings, which allows to send a list of custom config settings to the Container, e.g. -e customNavSettings="ReportPDFFontEmbedding=false,EnableSaveFromReportPreview=false" would disable font embedding in pdfs and saving from report preview. This addition is done in SetupVariables.ps1 and SetupConfiguration.ps1

2. A new env param myFilesPackage, which takes a URL to a zip file containing a my-folder, e.g. -e myFilesPackage="http://172.29.187.241:8080/my.zip". That zip file gets downloaded and extracted (almost) before anything else and the files in that folder get then picked up by the standard extension mechanism of the container. This addition is done in SetupVariables.ps1 and navstart.ps1