### PR TITLE
Log Warning event log entries

### DIFF
--- a/Run/MainLoop.ps1
+++ b/Run/MainLoop.ps1
@@ -2,7 +2,10 @@
 while ($true) 
 {
     $thisCheck = Get-Date 
-    Get-EventLog -LogName Application -After $lastCheck -ErrorAction Ignore | Where-Object { ($_.Source -like '*Dynamics*' -or $_.Source -eq $SqlServiceName) -and $_.EntryType -eq "Error" -and $_.EntryType -ne "0" } | Select-Object TimeGenerated, EntryType, Message | format-list
+    Get-EventLog -LogName Application -After $lastCheck -ErrorAction Ignore | Where-Object { `
+        ($_.Source -like '*Dynamics*' -or $_.Source -eq $SqlServiceName) -and `
+        ($_.EntryType -eq "Error" -or $_.EntryType -eq "Warning") -and $_.EntryType -ne "0" `
+    } | Select-Object TimeGenerated, EntryType, Message | format-list
     $lastCheck = $thisCheck 
     Start-Sleep -Seconds 2
 }


### PR DESCRIPTION
This PR references the issue #151.
I am really not sure if this change would be acceptable due to the increase of the data present in the docker output. Anyway, there are some useful entries (from my point of view errors) logged as warnings.