### PR TITLE
Fix Healthcheck

### DIFF
--- a/Run/Healthcheck.ps1
+++ b/Run/Healthcheck.ps1
@@ -3,3 +3,5 @@ if ((Test-Path "$PSScriptRoot\my" -PathType Container) -and (Test-Path "$PSScrip
 } else {
     . "$PSScriptRoot\CheckHealth.ps1"
 }
+
+exit $LASTEXITCODE


### PR DESCRIPTION
The exit code ist set by `CheckHealth.ps1` but the calling healthcheck script isn't using this exit code and therefore always returns 0. This way the container healthcheck would always succeed even though the container may be unhealthy.