### PR TITLE
reset ENV variables to fix #373

### DIFF
--- a/bc-w1/DOCKERFILE
+++ b/bc-w1/DOCKERFILE
@@ -18,6 +18,8 @@ COPY ./buildimage.ps1 /Run/buildimage.ps1
 
 RUN \Run\buildimage.ps1
 
+ENV DatabaseServer="" DatabaseInstance="" DatabaseName=""
+
 LABEL legal="$legal" \
       created="$created" \
       nav="$nav" \

--- a/dp-w1/DOCKERFILE
+++ b/dp-w1/DOCKERFILE
@@ -16,6 +16,8 @@ COPY ./buildimage.ps1 /Run/buildimage.ps1
 
 RUN \Run\buildimage.ps1
 
+ENV DatabaseServer="" DatabaseInstance="" DatabaseName=""
+
 LABEL legal="$legal" \
       created="$created" \
       nav="" \

--- a/nav-w1/DOCKERFILE
+++ b/nav-w1/DOCKERFILE
@@ -17,6 +17,8 @@ COPY ./buildimage.ps1 /Run/buildimage.ps1
 
 RUN \Run\buildimage.ps1
 
+ENV DatabaseServer="" DatabaseInstance="" DatabaseName=""
+
 LABEL legal="$legal" \
       created="$created" \
       nav="$nav" \


### PR DESCRIPTION
As described in #373 the env variables for the database settings inherit "defaults" from the Dockerfiles which leads to weird errors if you expect them (as I think is reasonable) to be empty