### PR TITLE
Add .app packages

### DIFF
--- a/generic/Run/130/navinstall.ps1
+++ b/generic/Run/130/navinstall.ps1
@@ -71,6 +71,10 @@ if (Test-Path "$navDvdPath\WindowsPowerShellScripts\WebSearch") {
     Copy-Item -Path "$navDvdPath\WindowsPowerShellScripts\WebSearch\" -Destination $runPath -Recurse -Force
 }
 
+if (Test-Path "ModernDev\program files\Microsoft Dynamics NAV\*\AL Development Environment") {
+    Copy-Item -Path "ModernDev\program files\Microsoft Dynamics NAV\*\AL Development Environment" -Destination $runPath -Recurse -Force
+}
+
 "ConfigurationPackages","Test Assemblies","TestToolKit","UpgradeToolKit","Extensions" | % {
     $dir = "$navDvdPath\$_" 
     if (Test-Path $dir -PathType Container)


### PR DESCRIPTION
The .app packages system.app, application.app and test.app are part of the installer and can be necessary when attaching the container to an external database. Therefore it would make sense to add them to the container image as well