### PR TITLE
Windows Password Expired

### DIFF
--- a/generic/Run/SetupWindowsUsers.ps1
+++ b/generic/Run/SetupWindowsUsers.ps1
@@ -9,7 +9,7 @@
 if ($auth -eq "Windows") {
     if (($securePassword) -and $username -ne "") { 
         Write-Host "Creating Windows user $username"
-        New-LocalUser -AccountNeverExpires -FullName $username -Name $username -Password $securePassword | Out-Null
+        New-LocalUser -AccountNeverExpires -PasswordNeverExpires -FullName $username -Name $username -Password $securePassword | Out-Null
         Add-LocalGroupMember -Group administrators -Member $username
     }
 }


### PR DESCRIPTION
If a container is older then 42 days, the error 

> 18452,"28000",[Microsoft][SQL Server Native Client 11.0][SQL Server]Login failed. The login is from an untrusted domain and cannot be used with Windows authentication.

occurs.

The flag PasswordNeverExpires should fix this issue.
