### PR TITLE
use correct casing at setting ApplicationInsightsInstrumentationKey

### DIFF
--- a/generic/Run/SetupConfiguration.ps1
+++ b/generic/Run/SetupConfiguration.ps1
@@ -25,7 +25,7 @@ $customConfig.SelectSingleNode("//appSettings/add[@key='ODataServicesPort']").Va
 $customConfig.SelectSingleNode("//appSettings/add[@key='DefaultClient']").Value = "Web"
 $customConfig.SelectSingleNode("//appSettings/add[@key='Multitenant']").Value = "$multitenant"
 if (!$multitenant -and "$applicationInsightsInstrumentationKey" -ne "") {
-    $customConfig.SelectSingleNode("//appSettings/add[@key='applicationInsightsInstrumentationKey']").Value = "$applicationInsightsInstrumentationKey"
+    $customConfig.SelectSingleNode("//appSettings/add[@key='ApplicationInsightsInstrumentationKey']").Value = "$applicationInsightsInstrumentationKey"
 }
 
 $taskSchedulerKeyExists = ($customConfig.SelectSingleNode("//appSettings/add[@key='EnableTaskScheduler']") -ne $null)
@@ -84,7 +84,7 @@ if ($isBcSandbox) {
 }
 
 if ($customNavSettings -ne "") {
-    Write-Host "Modifying Service Tier Config File with settings from environment variable"    
+    Write-Host "Modifying Service Tier Config File with settings from environment variable"
     Set-ConfigSetting -customSettings $customNavSettings -parentPath "//appSettings" -leafName "add" -customConfig $CustomConfig
 }
 


### PR DESCRIPTION
Hi, 

while creating a container with an ApplicationInsightsInstrumentationKey i got following error: 
![image](https://user-images.githubusercontent.com/22131101/102337655-0d406b00-3f93-11eb-8d11-94ccbaaf1eca.png)

Looking into the code [here](https://github.com/microsoft/nav-docker/blob/a33f281e9ef07bee963d9735cc75ef6483fb5a0e/generic/Run/SetupConfiguration.ps1#L28) ApplicationInsightsInstrumentationKey starts with a lower `a`.

Testing this line in a container i see that it is case sensitive. 
![image](https://user-images.githubusercontent.com/22131101/102337980-7c1dc400-3f93-11eb-9954-72e7effd15f6.png)
