### PR TITLE
Add windows server 2022

### DIFF
--- a/generic/buildall.ps1
+++ b/generic/buildall.ps1
@@ -14,6 +14,7 @@ function Head($text) {
 
 $push = $true
 $supported = @(
+    "10.0.20348.0"
     "10.0.19043.0"
     "10.0.19042.0"
     "10.0.19041.0"
@@ -55,6 +56,7 @@ $basetags = @(
 "4.8-windowsservercore-20H2"
 "4.8-windowsservercore-2004"
 "4.8-windowsservercore-1909"
+"4.8-windowsservercore-ltsc2022"
 "4.8-windowsservercore-ltsc2019"
 "4.8-windowsservercore-ltsc2016"
 )


### PR DESCRIPTION
Hey Freddy, 

i dont exactly know if BC is supported on Windows Server 2022. 
But i created a generic image and then a BC container and it works like a charm. 

If it's not supported yet, just tell me and i close this. :) 

Thanks. 