### PR TITLE
Correctly restore .ndf files on copy-navdatabase

### DIFF
--- a/generic/Run/HelperFunctions.ps1
+++ b/generic/Run/HelperFunctions.ps1
@@ -243,7 +243,7 @@ function Copy-NavDatabase
                                    -DatabaseCredentials $databaseCredentials `
                                    -Query $backupQuery
 
-            $move = (($files | % { $_.name+[System.IO.Path]::GetExtension($_.physical_name) }) -join "', move '").Replace(".mdf","' to '$dbfolder\$DestinationDatabaseName.mdf").Replace(".ldf","' to '$dbfolder\$DestinationDatabaseName.ldf")
+            $move = (($files | % { $_.name+[System.IO.Path]::GetExtension($_.physical_name) }) -join "', move '").Replace(".mdf","' to '$dbfolder\$DestinationDatabaseName.mdf").Replace(".ldf","' to '$dbfolder\$DestinationDatabaseName.ldf").Replace(".ndf","' to '$dbfolder\$DestinationDatabaseName.ndf")
 
             $restoreQuery = "restore database [$DestinationDatabaseName] from disk = '$dbfolder\$sourceDatabaseName.bak' with stats=10, recovery, move '$move'"
             Write-Host $restoreQuery


### PR DESCRIPTION
When using copy-navdatabase on a database that contains .ndf files, these do not get restored correctly and the command fails.

This is the SQL command that copy-navdatabase produced so far:
`restore database [tempmydatabase] from disk = 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\mydatabase.bak' with stats=10, recovery, move 'newsystem_Data' to 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\tempmydatabase.mdf', move 'newsystem_Log' to 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\tempmydatabase.ldf', move 'newsystem_1_Data.ndf'`

This is the SQL Command after the change:
`restore database [tempmydatabase] from disk = 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\mydatabase.bak' with stats=10, recovery, move 'newsystem_Data' to 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\tempmydatabase.mdf', move 'newsystem_Log' to 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\tempmydatabase.ldf', move 'newsystem_1_Data' to 'C:\Program Files\Microsoft SQL Server\MSSQL15.MSSQLSERVER\MSSQL\DATA\tempmydatabase.ndf'`