### PR TITLE
Always use UTC time for calculating initialization duration

### DIFF
--- a/generic/Run/navstart.ps1
+++ b/generic/Run/navstart.ps1
@@ -1,5 +1,5 @@
 Write-Host "Initializing..."
-$startTime = [DateTime]::Now
+$startTime = [DateTime]::UtcNow
 
 $runPath = "c:\Run"
 $myPath = Join-Path $runPath "my"
@@ -302,6 +302,6 @@ Write-Host "Container Total Physical Memory is $(($cimInstance.TotalVisibleMemor
 Write-Host "Container Free Physical Memory is $(($cimInstance.FreePhysicalMemory/1024/1024).ToString('F1',[CultureInfo]::InvariantCulture))Gb"
 Write-Host
 
-$timespend = [Math]::Round([DateTime]::Now.Subtract($startTime).Totalseconds)
+$timespend = [Math]::Round([DateTime]::UtcNow.Subtract($startTime).Totalseconds)
 Write-Host "Initialization took $timespend seconds"
 Write-Host "Ready for connections!"


### PR DESCRIPTION
During startup, we change the time zone to make sure users get the expected time zone in the Web Client as well. That leads to wrong initialization time calculation times: E.g. if a container starts, it records the startup time in UTC at 15:30:00, then we change to the German time zone, which is two hours later, so the end time would be e.g. 17:31:00 and the message would show "initialization took 7260 seconds", although in reality it would only be 1 minute. By always using UTC, we make sure that the calculation is correct.