### PR TITLE
Download artifacts in consistent way

### DIFF
--- a/generic/Run/HelperFunctions.ps1
+++ b/generic/Run/HelperFunctions.ps1
@@ -829,6 +829,7 @@ function Download-Artifacts {
 
     }
 }
+
 function Test-RunningArtifactPreparationWithWait {
     param (
         [Parameter(Mandatory = $true)]


### PR DESCRIPTION
### ARTIFACT CONSISTENCY PROBLEM:

We have realized that containers using shared folders to store artifacts were suffering from time to time from inconsistently downloaded artifacts.

When running on orchestrator, but basically whenever downloading artifacts from containers (and not from BcContainerHelper from the host machine) and using a shared folder, it's not possible to use mutext (which is the difference between in-container download vs. download on the host using BCCH) and guarantee only one process accessing the shared resources.

The provided functionality uses file lock that controls access and guarantees only one process can access and other containers will be waiting until done (with success or not).