### PR TITLE
use master branch

### DIFF
--- a/.github/workflows/BuildMissingImages.yaml
+++ b/.github/workflows/BuildMissingImages.yaml
@@ -18,7 +18,7 @@ env:
   resGroup: "buildgeneric"
   resLocation: "West Europe"
   machines: "2"
-  ARMbranch: "dev"
+  ARMbranch: "master"
   ARMtemplate: "buildagent"
 
 

--- a/.github/workflows/CreateAgents.yaml
+++ b/.github/workflows/CreateAgents.yaml
@@ -19,7 +19,7 @@ env:
   resGroup: "buildgeneric"
   resLocation: "West Europe"
   machines: "5"
-  ARMbranch: "dev"
+  ARMbranch: "master"
   ARMtemplate: "buildagent"
 
 jobs:

--- a/.github/workflows/UpdateExistingImages.yaml
+++ b/.github/workflows/UpdateExistingImages.yaml
@@ -37,7 +37,7 @@ env:
   resGroup: "buildgeneric"
   resLocation: "West Europe"
   machines: "5"
-  ARMbranch: "dev"
+  ARMbranch: "master"
   ARMtemplate: "buildagent"
 
 jobs:


### PR DESCRIPTION
Use master branch from nav-arm-templates when generating AzureVMs for building images.