### PR TITLE
Enhance Resilience of StartCount.txt in navstart.ps1

### DIFF
--- a/generic/Run/navstart.ps1
+++ b/generic/Run/navstart.ps1
@@ -41,7 +41,9 @@ if ($restartingInstance) {
 
 $startCount = 0
 if (Test-Path $startCountFile -PathType Leaf) {
-    $startCount = [int](Get-Content -Path $startCountFile)
+    if (![int]::TryParse((Get-Content -Path $startCountFile), [ref]$startCount)) {
+        $startCount = 0
+    }
 }
 $startCount++
 if ($startCount -gt 1) {


### PR DESCRIPTION
Today, I encountered an issue where my StartCount.txt file contained random characters that couldn’t be parsed. These unexpected characters caused startup problems for my containers.

![image](https://github.com/microsoft/nav-docker/assets/16477556/85622254-9889-40c0-aeaa-a4bec3183378)

It has also been reported here https://github.com/microsoft/navcontainerhelper/issues/2804 but I do not see how this is an issue with the BcContainerHelper.

To address this, I propose an update to the code in navstart.ps1 to be more resilient when reading the file, more specifically if the content is not parsable simply set it to 0.