### PR TITLE
Add support for Wix 6 generated DVD image in version 270 and later.

### DIFF
--- a/generic/Run/270/ServiceSettings.ps1
+++ b/generic/Run/270/ServiceSettings.ps1
@@ -1,0 +1,3 @@
+﻿$NavServiceName = 'MicrosoftDynamicsNavServer$BC'
+$WebServerInstance = "BC"
+$ServerInstance = "BC"

--- a/generic/Run/270/SetupConfiguration.ps1
+++ b/generic/Run/270/SetupConfiguration.ps1
@@ -1,0 +1,138 @@
+﻿# INPUT
+#     $auth
+#     $protocol
+#     $publicDnsName
+#     $ServiceTierFolder
+#     $navUseSSL
+#     $servicesUseSSL
+#     $certificateThumbprint
+#
+# OUTPUT
+#
+
+Write-Host "Modifying Service Tier Config File with Instance Specific Settings"
+$CustomConfigFile =  Join-Path $ServiceTierFolder "CustomSettings.config"
+$CustomConfig = [xml](Get-Content $CustomConfigFile)
+
+$customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseServer']").Value = $databaseServer
+$customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseInstance']").Value = $databaseInstance
+$customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseName']").Value = "$databaseName"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ServerInstance']").Value = "$serverInstance"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ManagementServicesPort']").Value = "$managementServicesPort"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ClientServicesPort']").Value = "$clientServicesPort"
+$customConfig.SelectSingleNode("//appSettings/add[@key='SOAPServicesPort']").Value = "$soapServicesPort"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ODataServicesPort']").Value = "$oDataServicesPort"
+$customConfig.SelectSingleNode("//appSettings/add[@key='DefaultClient']").Value = "Web"
+$customConfig.SelectSingleNode("//appSettings/add[@key='Multitenant']").Value = "$multitenant"
+if (!$multitenant -and "$applicationInsightsInstrumentationKey" -ne "") {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='ApplicationInsightsInstrumentationKey']").Value = "$applicationInsightsInstrumentationKey"
+}
+
+$taskSchedulerKeyExists = ($customConfig.SelectSingleNode("//appSettings/add[@key='EnableTaskScheduler']") -ne $null)
+if ($taskSchedulerKeyExists) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='EnableTaskScheduler']").Value = "false"
+}
+
+$developerServicesKeyExists = ($customConfig.SelectSingleNode("//appSettings/add[@key='DeveloperServicesPort']") -ne $null)
+if ($developerServicesKeyExists) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='DeveloperServicesPort']").Value = "$developerServicesPort"
+    $customConfig.SelectSingleNode("//appSettings/add[@key='DeveloperServicesEnabled']").Value = "true"
+    $CustomConfig.SelectSingleNode("//appSettings/add[@key='DeveloperServicesSSLEnabled']").Value = $servicesUseSSL.ToString().ToLower()
+}
+
+$SnapshotDebuggerKeyExists = ($customConfig.SelectSingleNode("//appSettings/add[@key='SnapshotDebuggerServicesPort']") -ne $null)
+if ($SnapshotDebuggerKeyExists) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='SnapshotDebuggerServicesPort']").Value = "$snapshotDebuggerServicesPort"
+    $customConfig.SelectSingleNode("//appSettings/add[@key='SnapshotDebuggerEnabled']").Value = "true"
+    $CustomConfig.SelectSingleNode("//appSettings/add[@key='SnapshotDebuggerServicesSSLEnabled']").Value = $servicesUseSSL.ToString().ToLower()
+}
+
+$customConfig.SelectSingleNode("//appSettings/add[@key='ClientServicesCredentialType']").Value = $auth
+if ($developerServicesKeyExists) {
+    $publicWebBaseUrl = "$protocol$publicDnsName$publicwebClientPort/$WebServerInstance/"
+} else {
+    $publicWebBaseUrl = "$protocol$publicDnsName$publicwebClientPort/$WebServerInstance/WebClient/"
+}
+if ($WebClient -ne "N") {
+    $CustomConfig.SelectSingleNode("//appSettings/add[@key='PublicWebBaseUrl']").Value = $publicWebBaseUrl
+}
+$CustomConfig.SelectSingleNode("//appSettings/add[@key='PublicSOAPBaseUrl']").Value = "$protocol${publicDnsName}:$publicSoapPort/$ServerInstance/WS/"
+$CustomConfig.SelectSingleNode("//appSettings/add[@key='PublicODataBaseUrl']").Value = "$protocol${publicDnsName}:$publicODataPort/$ServerInstance/OData"
+$CustomConfig.SelectSingleNode("//appSettings/add[@key='PublicWinBaseUrl']").Value = "DynamicsNAV://${publicDnsName}:$publicWinClientPort/$ServerInstance/"
+if ($servicesUseSSL) {
+    $CustomConfig.SelectSingleNode("//appSettings/add[@key='ServicesCertificateThumbprint']").Value = "$certificateThumbprint"
+    $CustomConfig.SelectSingleNode("//appSettings/add[@key='ServicesCertificateValidationEnabled']").Value = "false"
+}
+
+$CustomConfig.SelectSingleNode("//appSettings/add[@key='SOAPServicesSSLEnabled']").Value = $servicesUseSSL.ToString().ToLower()
+$CustomConfig.SelectSingleNode("//appSettings/add[@key='ODataServicesSSLEnabled']").Value = $servicesUseSSL.ToString().ToLower()
+
+$enableSymbolLoadingAtServerStartupKeyExists = ($customConfig.SelectSingleNode("//appSettings/add[@key='EnableSymbolLoadingAtServerStartup']") -ne $null)
+if ($enableSymbolLoadingAtServerStartupKeyExists) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='EnableSymbolLoadingAtServerStartup']").Value = "$($enableSymbolLoadingAtServerStartup -eq $true)"
+}
+
+$apiServicesEnabledExists = ($customConfig.SelectSingleNode("//appSettings/add[@key='ApiServicesEnabled']") -ne $null)
+if (($enableApiServices -ne $null) -and $apiServicesEnabledExists) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='ApiServicesEnabled']").Value = "$($enableApiServices -eq $true)"
+}
+
+if ($isBcSandbox) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='EnableTaskScheduler']").Value = "true"
+    Set-ConfigSetting -customSettings "TenantEnvironmentType=Sandbox" -parentPath "//appSettings" -leafName "add" -customConfig $customConfig -silent
+    Set-ConfigSetting -customSettings "EnableSaasExtensionInstall=true" -parentPath "//appSettings" -leafName "add" -customConfig $customConfig -silent
+}
+
+if ($customNavSettings -ne "") {
+    Write-Host "Modifying Service Tier Config File with settings from environment variable"    
+    Set-ConfigSetting -customSettings $customNavSettings -parentPath "//appSettings" -leafName "add" -customConfig $CustomConfig
+}
+
+if ($auth -eq "AccessControlService") {
+    if ($appIdUri -eq "") {
+        $appIdUri = "$publicWebBaseUrl"
+    }
+    if ("$aadTenant" -eq "") {
+        $aadTenant = "Common"
+    }
+    if ($federationMetadata -eq "") {
+        $federationMetadata = "https://login.microsoftonline.com/$aadTenant/FederationMetadata/2007-06/FederationMetadata.xml"
+    }
+    if ($federationLoginEndpoint -eq "") {
+        $federationLoginEndpoint = "https://login.microsoftonline.com/$aadTenant/wsfed?wa=wsignin1.0%26wtrealm=$appIdUri"
+    }
+
+    $customConfig.SelectSingleNode("//appSettings/add[@key='AppIdUri']").Value = $appIdUri
+    $clientServicesFederationMetadataLocationNode = $customConfig.SelectSingleNode("//appSettings/add[@key='ClientServicesFederationMetadataLocation']")
+    if ($clientServicesFederationMetadataLocationNode) {
+        $clientServicesFederationMetadataLocationNode.Value = $federationMetadata
+    }
+    $WSFederationLoginEndpointNode = $customConfig.SelectSingleNode("//appSettings/add[@key='WSFederationLoginEndpoint']")
+    if ($WSFederationLoginEndpointNode) {
+        $WSFederationLoginEndpointNode.Value = $federationLoginEndpoint
+    }
+    $ADOpenIdMetadataLocationNode = $customConfig.SelectSingleNode("//appSettings/add[@key='ADOpenIdMetadataLocation']")
+    if ($ADOpenIdMetadataLocationNode -and $ADOpenIdMetadataLocationNode.Value -eq "") {
+        $ADOpenIdMetadataLocationNode.Value = "https://login.microsoftonline.com/common/.well-known/openid-configuration"
+    }
+}
+
+$CustomConfig.Save($CustomConfigFile)
+
+$managementServicesPort,$soapServicesPort,$oDataServicesPort,$developerServicesPort,$SnapshotDebuggerServicesPort | % {
+    netsh http add urlacl url=$protocol+:$_/$ServerInstance user="NT AUTHORITY\SYSTEM" | Out-Null
+    if ($servicesUseSSL) {
+        netsh http add sslcert ipport=0.0.0.0:$_ certhash=$certificateThumbprint appid="{00112233-4455-6677-8899-AABBCCDDEEFF}" | Out-Null
+    }
+}
+netsh http add urlacl url=http://+:$clientServicesPort/$ServerInstance user="NT AUTHORITY\SYSTEM" | Out-Null
+
+if ($developerServicesKeyExists) {
+    $serverConfigFile = Join-Path $ServiceTierFolder "Microsoft.Dynamics.Nav.Server.exe.config"
+    $serverConfig = [xml](Get-Content -Path $serverConfigFile)
+    $legacySecurityPolicyNode = $serverConfig.SelectSingleNode("//configuration/runtime/NetFx40_LegacySecurityPolicy")
+    if ($legacySecurityPolicyNode) {
+        $legacySecurityPolicyNode.enabled = "false"
+    }
+    $serverConfig.Save($serverConfigFile)
+}

--- a/generic/Run/270/SetupWebClient.ps1
+++ b/generic/Run/270/SetupWebClient.ps1
@@ -1,0 +1,84 @@
+﻿# Remove Default Web Site
+Get-WebSite | Remove-WebSite
+Get-WebBinding | Remove-WebBinding
+
+$certparam = @{}
+if ($servicesUseSSL) {
+    Write-Host "CertificateThumprint $certificateThumbprint"
+    $certparam += @{CertificateThumbprint = $certificateThumbprint}
+}
+
+Write-Host "Registering event sources"
+"MicrosoftDynamicsNAVClientWebClient","MicrosoftDynamicsNAVClientClientService" | % {
+    if (-not [System.Diagnostics.EventLog]::SourceExists($_)) {
+        $frameworkDir =  (Get-Item "HKLM:\SOFTWARE\Microsoft\.NETFramework").GetValue("InstallRoot")
+        New-EventLog -LogName Application -Source $_ -MessageResourceFile (get-item (Join-Path $frameworkDir "*\EventLogMessages.dll")).FullName
+    }
+}
+
+Write-Host "Creating DotNetCore Web Server Instance"
+$publishFolder = "$webClientFolder\WebPublish"
+
+$runtimeConfigJsonFile = Join-Path $publishFolder "Prod.Client.WebCoreApp.runtimeconfig.json"
+if (Test-Path $runtimeConfigJsonFile) {
+    $runtimeConfigJson = Get-Content $runtimeConfigJsonFile | ConvertFrom-Json
+    if (!($runtimeConfigJson.runtimeOptions.configProperties.PSObject.Properties.Name -eq "System.Globalization.UseNls")) {
+        Add-Member -InputObject $runtimeConfigJson.runtimeOptions.configProperties -NotePropertyName "System.Globalization.UseNls" -NotePropertyValue "true"
+        $runtimeConfigJson | ConvertTo-Json -Depth 99 | Set-Content $runtimeConfigJsonFile
+    }
+}
+
+$NAVWebClientManagementModule = "$webClientFolder\Modules\NAVWebClientManagement\NAVWebClientManagement.psm1"
+if (!(Test-Path $NAVWebClientManagementModule)) {
+    $NAVWebClientManagementModule = "$webClientFolder\Scripts\NAVWebClientManagement.psm1"
+}
+# Replace Copy with Robocopy
+$WebManagementModuleSource = Get-Content -Path $NAVWebClientManagementModule -Raw -Encoding UTF8
+$WebManagementModuleSource = $WebManagementModuleSource.Replace('Copy-Item $SourcePath -Destination $siteRootFolder -Recurse -Container -Force','RoboCopy "$SourcePath" "$siteRootFolder" "*" /e /NFL /NDL /NJH /NJS /nc /ns /np /mt /z /nooffload | Out-Null
+Get-ChildItem -Path $SourcePath -Filter "*" -Recurse | ForEach-Object {
+    $destPath = Join-Path $siteRootFolder $_.FullName.Substring($SourcePath.Length)
+    while (!(Test-Path $destPath)) {
+        Write-Host "Waiting for $destPath to be available"
+        Start-Sleep -Seconds 1
+    }
+}')
+$WebManagementModuleSource = $WebManagementModuleSource.Replace('Write-Verbose','Write-Host')
+$NAVWebClientManagementModule = "c:\run\my\NAVWebClientManagement.psm1"
+Set-Content -Path $NAVWebClientManagementModule -Value $WebManagementModuleSource -Encoding UTF8
+
+Import-Module $NAVWebClientManagementModule
+New-NAVWebServerInstance -PublishFolder $publishFolder `
+                         -WebServerInstance "$WebServerInstance" `
+                         -Server "localhost" `
+                         -ServerInstance "$ServerInstance" `
+                         -ClientServicesCredentialType $Auth `
+                         -ClientServicesPort "$clientServicesPort" `
+                         -WebSitePort $webClientPort @certparam
+
+$navsettingsFile = Join-Path $wwwRootPath "$WebServerInstance\navsettings.json"
+$config = Get-Content $navSettingsFile | ConvertFrom-Json
+Add-Member -InputObject $config.NAVWebSettings -NotePropertyName "RequireSSL" -NotePropertyValue "true" -ErrorAction SilentlyContinue
+$config.NAVWebSettings.RequireSSL = $false
+Add-Member -InputObject $config.NAVWebSettings -NotePropertyName "PersonalizationEnabled" -NotePropertyValue "true" -ErrorAction SilentlyContinue
+$config.NAVWebSettings.PersonalizationEnabled = $true
+$config.NAVWebSettings.ManagementServicesPort = $ManagementServicesPort
+
+if ($customWebSettings -ne "") {
+    Write-Host "Modifying Web Client config with settings from environment variable"        
+
+    $customWebSettingsArray = $customWebSettings -split ","
+    foreach ($customWebSetting in $customWebSettingsArray) {
+        $customWebSettingArray = $customWebSetting -split "="
+        $customWebSettingKey = $customWebSettingArray[0]
+        $customWebSettingValue = $customWebSettingArray[1]
+        if ($config.NAVWebSettings.$customWebSettingKey -eq $null) {
+            Write-Host "Creating $customWebSettingKey and setting it to $customWebSettingValue"
+            $config.NAVWebSettings | Add-Member $customWebSettingKey $customWebSettingValue
+        } else {
+            Write-Host "Setting $customWebSettingKey to $customWebSettingValue"
+            $config.NAVWebSettings.$customWebSettingKey = $customWebSettingValue
+        }
+    }
+}
+
+$config | ConvertTo-Json | set-content $navSettingsFile

--- a/generic/Run/270/navinstall.ps1
+++ b/generic/Run/270/navinstall.ps1
@@ -1,0 +1,391 @@
+Param( 
+    [switch] $installOnly,
+    [switch] $filesOnly,
+    [string] $appArtifactPath = "",
+    [string] $platformArtifactPath = "",
+    [string] $databasePath = "",
+    [string] $licenseFilePath = "",
+    [switch] $multitenant,
+    [switch] $includeTestToolkit,
+    [switch] $includeTestLibrariesOnly,
+    [switch] $includeTestFrameworkOnly,
+    [switch] $includePerformanceToolkit,
+    [switch] $rebootContainer
+)
+
+Write-Host "Installing Business Central: multitenant=$($multitenant.IsPresent), installOnly=$($installOnly.IsPresent), filesOnly=$($filesOnly.IsPresent), includeTestToolkit=$($includeTestToolkit.IsPresent), includeTestLibrariesOnly=$($includeTestLibrariesOnly.IsPresent), includeTestFrameworkOnly=$($includeTestFrameworkOnly.IsPresent), includePerformanceToolkit=$($includePerformanceToolkit.IsPresent), appArtifactPath=$appArtifactPath, platformArtifactPath=$platformArtifactPath, databasePath=$databasePath, licenseFilePath=$licenseFilePath, rebootContainer=$($rebootContainer.IsPresent)"
+$startTime = [DateTime]::Now
+
+$runPath = "c:\Run"
+$myPath = Join-Path $runPath "my"
+$navDvdPath = "C:\NAVDVD"
+
+function Get-MyFilePath([string]$FileName)
+{
+    if ((Test-Path $myPath -PathType Container) -and (Test-Path (Join-Path $myPath $FileName) -PathType Leaf)) {
+        (Join-Path $myPath $FileName)
+    } else {
+        (Join-Path $runPath $FileName)
+    }
+}
+
+function Get-ExistingDirectory([string]$pri1, [string]$pri2, [string]$folder)
+{
+    if ($pri1 -and (Test-Path (Join-Path $pri1 $folder))) {
+        (Get-Item (Join-Path $pri1 $folder)).FullName
+    }
+    elseif ($pri2 -and (Test-Path (Join-Path $pri2 $folder))) {
+        (Get-Item (Join-Path $pri2 $folder)).FullName
+    }
+    else {
+        ""
+    }
+}
+
+. (Get-MyFilePath "ServiceSettings.ps1")
+. (Get-MyFilePath "HelperFunctions.ps1")
+. (Get-MyFilePath "GetDvdArtifactPaths.ps1")
+
+$installFromArtifacts = ($appArtifactPath -ne "" -and $platformArtifactPath -ne "")
+if ($installFromArtifacts) {
+    Write-Host "Installing from artifacts"
+    $navDvdPath = $platformArtifactPath
+}
+else {
+    Write-Host "Installing from DVD"
+}
+
+if (!(Test-Path $navDvdPath -PathType Container)) {
+    Write-Error "DVD folder not found
+You must map a folder on the host with the DVD content to $navDvdPath"
+    exit 1
+}
+
+$skipDb = $filesOnly
+
+
+if (!$skipDb) {
+
+    $databaseFolder = "c:\databases"
+    New-Item -Path $databaseFolder -itemtype Directory -ErrorAction Ignore | Out-Null
+
+    # SQL Express 2019
+    Set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql15.SQLEXPRESS\mssqlserver' -name DefaultData -value $databaseFolder -ErrorAction SilentlyContinue
+    Set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql15.SQLEXPRESS\mssqlserver' -name DefaultLog -value $databaseFolder -ErrorAction SilentlyContinue
+
+    # SQL Express 2022
+    Set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql16.SQLEXPRESS\mssqlserver' -name DefaultData -value $databaseFolder -ErrorAction SilentlyContinue
+    Set-itemproperty -path 'HKLM:\software\microsoft\microsoft sql server\mssql16.SQLEXPRESS\mssqlserver' -name DefaultLog -value $databaseFolder -ErrorAction SilentlyContinue
+
+    # start the SQL Server
+    Write-Host "Starting Local SQL Server"
+    Start-Service -Name $SqlBrowserServiceName
+    Start-Service -Name $SqlWriterServiceName
+    Start-Service -Name $SqlServiceName
+
+    # start IIS services
+    Write-Host "Starting Internet Information Server"
+    Start-Service -name $IisServiceName
+}
+
+Write-Host "Copying Service Tier Files"
+RoboCopyFiles -Source (Join-Path "$NavDvdPath\ServiceTier" (Get-WixProgramFiles64 "$NavDvdPath"))  -Destination "C:\Program Files" -e
+RoboCopyFiles -Source (Get-NavDvdSipComponentPath "$NavDvdPath") -Destination "C:\Windows\System32" -Files "NavSip.dll" -e
+
+Write-Host "Copying Web Client Files"
+RoboCopyFiles -Source (Get-NavDvdWebClientFolder "$NavDvdPath") -Destination "C:\Program Files\Microsoft Dynamics NAV" -e
+
+if (Test-Path "$navDvdPath\RoleTailoredClient\program files\Microsoft Dynamics NAV\*\RoleTailored Client" -PathType Container) {
+    Write-Host "Copying Client Files"
+    RoboCopyFiles -Source "$navDvdPath\RoleTailoredClient\program files\Microsoft Dynamics NAV" -Destination "C:\Program Files (x86)\Microsoft Dynamics NAV" -Files "*.dll" -e
+    RoboCopyFiles -Source "$navDvdPath\RoleTailoredClient\program files\Microsoft Dynamics NAV" -Destination "C:\Program Files (x86)\Microsoft Dynamics NAV" -Files "*.exe" -e
+    RoboCopyFiles -Source "$navDvdPath\RoleTailoredClient\systemFolder" -Destination "C:\Windows\SysWow64" -Files "NavSip.dll"
+}
+
+if (Test-Path "$navDvdPath\LegacyDlls\program files\Microsoft Dynamics NAV\*\RoleTailored Client" -PathType Container) {
+    Write-Host "Copying Client Files"
+    RoboCopyFiles -Source "$navDvdPath\LegacyDlls\program files\Microsoft Dynamics NAV" -Destination "C:\Program Files (x86)\Microsoft Dynamics NAV" -Files "*.dll" -e
+    RoboCopyFiles -Source "$navDvdPath\LegacyDlls\program files\Microsoft Dynamics NAV" -Destination "C:\Program Files (x86)\Microsoft Dynamics NAV" -Files "*.exe" -e
+    RoboCopyFiles -Source "$navDvdPath\LegacyDlls\systemFolder" -Destination "C:\Windows\SysWow64" -Files "NavSip.dll"
+}
+
+Write-Host "Copying ModernDev Files"
+RoboCopyFiles -Source "$navDvdPath" -Destination "$runPath" -Files "*.vsix"
+$DevToolsPath = (Get-NavDvdDevToolsFolder $navDvdPath)
+if (!($null -eq $DevToolsPath) -and (Test-Path "$DevToolsPath")) {
+    RoboCopyFiles -Source "$DevToolsPath" -Destination "C:\Program Files\Microsoft Dynamics NAV" -e
+}
+
+if (!($null -eq $DevToolsPath)) {
+    if ((Test-Path "$DevToolsPath\*\*\*.vsix") -and !(Test-Path (Join-Path $runPath "*.vsix"))) {
+        Copy-Item -Path "$DevToolsPath\*\*\*.vsix" -Destination $runPath -Force
+    }    
+}
+
+Write-Host "Copying additional files"
+"ConfigurationPackages","Test Assemblies","TestToolKit","UpgradeToolKit","Extensions","Applications","Applications.*","My" | ForEach-Object {
+    $dir = Get-ExistingDirectory -pri1 $appArtifactPath -pri2 $navDvdPath -folder $_
+    if ($dir)
+    {
+        $name = [System.IO.Path]::GetFileName($dir)
+        Write-Host "Copying $name"
+        RoboCopyFiles -Source "$dir" -Destination "C:\$name" -e
+    }
+}
+
+$mockAssembliesPath = "C:\Test Assemblies\Mock Assemblies"
+if (Test-Path $mockAssembliesPath) {
+    $serviceTierAddInsFolder = (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service\Add-ins").FullName
+    if (!(Test-Path (Join-Path $serviceTierAddInsFolder "Mock Assemblies"))) {
+        new-item -itemtype symboliclink -path $serviceTierAddInsFolder -name "Mock Assemblies" -value $mockAssembliesPath | Out-Null
+    }
+}
+
+$installersFolder = Get-ExistingDirectory -pri1 $appArtifactPath -pri2 $navDvdPath -folder "Intallers"
+if ($installersFolder) {
+    Get-ChildItem $installersFolder -Recurse | Where-Object { $_.PSIsContainer } | ForEach-Object {
+        Get-ChildItem $_.FullName | Where-Object { $_.PSIsContainer } | ForEach-Object {
+            $dir = $_.FullName
+            Get-ChildItem (Join-Path $dir "*.msi") | ForEach-Object {
+                $filepath = $_.FullName
+                if ($filepath.Contains('\WebHelp\')) {
+                    Write-Host "Skipping $filepath"
+                } else {
+                    Write-Host "Installing $filepath"
+                    Start-Process -FilePath $filepath -WorkingDirectory $dir -ArgumentList "/qn /norestart" -Wait
+                }
+            }
+        }
+    }
+}
+
+Write-Host "Copying dependencies"
+$serviceTierFolder = (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service").FullName
+Copy-Item -Path (Join-Path $runPath 'Install\t2embed.dll') -Destination "c:\windows\system32\t2embed.dll"
+
+Write-Host "Importing PowerShell Modules"
+try {
+    Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Management.psm1"
+}
+catch {
+    Write-Host "Error: '$($_.Exception.Message)', Retrying in 10 seconds..."
+    Start-Sleep -Seconds 10
+    Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Management.psm1"
+}
+
+$databaseServer = "localhost"
+$databaseInstance = "SQLEXPRESS"
+if ($multitenant) {
+    $databaseName = "tenant"
+}
+else {
+    $databaseName = "CRONUS"
+}
+
+# Restore CRONUS Demo database to databases folder
+$CommonAppData = Get-WixCommonAppData "$navDvdPath"
+if (!$skipDb -and $databasePath) {
+
+    if (Test-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName) {
+        Write-Host "Removing database $databaseName"
+        Remove-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName
+    }
+
+    Write-Host "Restoring CRONUS Demo Database"
+    New-NAVDatabase -DatabaseServer $databaseServer `
+                    -DatabaseInstance $databaseInstance `
+                    -DatabaseName "$databaseName" `
+                    -FilePath "$databasePath" `
+                    -DestinationPath "$databaseFolder" `
+                    -Timeout 300 | Out-Null
+
+    Set-DatabaseCompatibilityLevel -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseName $databaseName
+}
+elseif (!$skipDb -and (Test-Path "$navDvdPath\SQLDemoDatabase" -PathType Container)) {
+    $bak = (Get-ChildItem -Path "$navDvdPath\SQLDemoDatabase\$CommonAppData\Microsoft\Microsoft Dynamics NAV\*\Database\*.bak")[0]
+    
+    $databaseFile = $bak.FullName
+
+    if (Test-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName) {
+        Write-Host "Removing database $databaseName"
+        Remove-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName
+    }
+
+    Write-Host "Restoring CRONUS Demo Database"
+    New-NAVDatabase -DatabaseServer $databaseServer `
+                    -DatabaseInstance $databaseInstance `
+                    -DatabaseName "$databaseName" `
+                    -FilePath "$databaseFile" `
+                    -DestinationPath "$databaseFolder" `
+                    -Timeout 300 | Out-Null
+
+    Set-DatabaseCompatibilityLevel -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseName $databaseName
+}
+elseif (!$skipDb -and (Test-Path "$navDvdPath\databases")) {
+
+    $multitenant = $false
+    $databaseName = "CRONUS"
+
+    if (Test-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName) {
+        Write-Host "Removing database $databaseName"
+        Remove-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName
+    }
+
+    Write-Host "Copying Cronus database"
+    RoboCopy "$navDvdPath\databases" "c:\databases" /e /NFL /NDL /NJH /NJS /nc /ns /np /mt /z /nooffload | Out-Null
+    $mdf = (Get-Item "C:\databases\*.mdf").FullName
+    $ldf = (Get-Item "C:\databases\*.ldf").FullName
+    $attachcmd = @"
+USE [master]
+GO
+CREATE DATABASE [$databaseName] ON (FILENAME = '$mdf'),(FILENAME = '$ldf') FOR ATTACH
+GO
+"@
+    Invoke-Sqlcmd -ServerInstance localhost\SQLEXPRESS -QueryTimeOut 0 -ea Stop -Query $attachcmd
+
+    Set-DatabaseCompatibilityLevel -DatabaseServer localhost -DatabaseInstance SQLEXPRESS -DatabaseName "$databaseName"
+}
+else {
+    $skipDb = $true
+    Write-Host "Skipping restore of Cronus database"
+}
+
+$databaseName = "CRONUS"
+
+if (!$skipDb) {
+    if ($multitenant) {
+        if (Test-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName) {
+            Write-Host "Removing database $databaseName"
+            Remove-NavDatabase -DatabaseServer $databaseServer -DatabaseInstance $databaseInstance -DatabaseCredentials $databaseCredentials -DatabaseName $databaseName
+        }
+        Write-Host "Exporting Application to $DatabaseName"
+        Invoke-sqlcmd -serverinstance "$DatabaseServer\$DatabaseInstance" -Database tenant -query 'CREATE USER "NT AUTHORITY\SYSTEM" FOR LOGIN "NT AUTHORITY\SYSTEM";'
+        Export-NAVApplication -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance -DatabaseName "tenant" -DestinationDatabaseName $databaseName -Force -ServiceAccount 'NT AUTHORITY\SYSTEM' | Out-Null
+        Write-Host "Removing Application from tenant"
+        Remove-NAVApplication -DatabaseServer $DatabaseServer -DatabaseInstance $DatabaseInstance -DatabaseName "tenant" -Force | Out-Null
+    }
+    else {
+        Invoke-Sqlcmd -ServerInstance "$DatabaseServer\$DatabaseInstance" -Database $databaseName -Query "UPDATE [dbo].[`$ndo`$tenantproperty] SET [tenantid] = 'default' WHERE [tenantid] = ''" -ErrorAction Ignore
+    }
+}
+
+Write-Host "Modifying Business Central Service Tier Config File for Docker"
+$CustomConfigFile =  Join-Path $serviceTierFolder "CustomSettings.config"
+$CustomConfig = [xml](Get-Content $CustomConfigFile)
+$customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseServer']").Value = $databaseServer
+$customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseInstance']").Value = $databaseInstance
+$customConfig.SelectSingleNode("//appSettings/add[@key='DatabaseName']").Value = "$databaseName"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ServerInstance']").Value = "$serverInstance"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ManagementServicesPort']").Value = "7045"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ClientServicesPort']").Value = "7046"
+$customConfig.SelectSingleNode("//appSettings/add[@key='SOAPServicesPort']").Value = "7047"
+$customConfig.SelectSingleNode("//appSettings/add[@key='ODataServicesPort']").Value = "7048"
+$customConfig.SelectSingleNode("//appSettings/add[@key='DeveloperServicesPort']").Value = "7049"
+$customConfig.SelectSingleNode("//appSettings/add[@key='DefaultClient']").Value = "Web"
+$customConfig.SelectSingleNode("//appSettings/add[@key='Multitenant']").Value = "$multitenant"
+$taskSchedulerKeyExists = ($null -ne $customConfig.SelectSingleNode("//appSettings/add[@key='EnableTaskScheduler']"))
+if ($taskSchedulerKeyExists) {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='EnableTaskScheduler']").Value = "false"
+}
+if ($null -eq $customConfig.SelectSingleNode("//appSettings/add[@key='ClrRetrieverKind']")) {
+    $element = $customConfig.CreateElement("add")
+    $element.SetAttribute("key", "ClrRetrieverKind")
+    $element.SetAttribute("value", "OneApplicationObjectOneAssembly")
+    $customConfig.SelectSingleNode("//appSettings").AppendChild($element) | Out-Null
+}
+else {
+    $customConfig.SelectSingleNode("//appSettings/add[@key='ClrRetrieverKind']").Value = "OneApplicationObjectOneAssembly"
+}
+
+$CustomConfig.Save($CustomConfigFile)
+
+$serverFile = "$serviceTierFolder\Microsoft.Dynamics.Nav.Server.exe"
+if (!$filesOnly) {
+    # Creating Business Central Service
+    Write-Host "Creating Business Central Service Tier"
+    $serviceCredentials = New-Object System.Management.Automation.PSCredential ("NT AUTHORITY\SYSTEM", (new-object System.Security.SecureString))
+    $configFile = "$serviceTierFolder\Microsoft.Dynamics.Nav.Server.exe.config"
+    New-Service -Name $NavServiceName -BinaryPathName """$serverFile"" `$$ServerInstance /config ""$configFile""" -DisplayName "Dynamics 365 Business Central Server [$ServerInstance]" -Description "$serverInstance" -StartupType manual -Credential $serviceCredentials -DependsOn @("HTTP") | Out-Null
+}
+$serverVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($serverFile)
+$versionFolder = ("{0}{1}" -f $serverVersion.FileMajorPart,$serverVersion.FileMinorPart)
+$registryPath = "HKLM:\SOFTWARE\Microsoft\Microsoft Dynamics NAV\$versionFolder\Service"
+New-Item -Path $registryPath -Force | Out-Null
+New-ItemProperty -Path $registryPath -Name 'Path' -Value "$serviceTierFolder\" -Force | Out-Null
+New-ItemProperty -Path $registryPath -Name 'Installed' -Value 1 -Force | Out-Null
+
+Install-NAVSipCryptoProvider
+
+$installApps = @()
+if ($includeTestToolkit) {
+    $installApps += GetTestToolkitApps -includeTestLibrariesOnly:$includeTestLibrariesOnly -includeTestFrameworkOnly:$includeTestFrameworkOnly -includePerformanceToolkit:$includePerformanceToolkit
+}
+
+$installApps | Out-Host
+
+if (!$skipDb -and ($multitenant -or $installOnly -or $licenseFilePath -ne "" -or ($installApps) -or (Test-Path "$navDvdPath\SQLDemoDatabase\CommonAppData\Microsoft\Microsoft Dynamics NAV\*\Database\cronus.flf"))) {
+    Write-Host "Starting Business Central Service Tier"
+    Start-Service -Name $NavServiceName -WarningAction Ignore
+
+    if ($licenseFilePath -ne "") {
+        Write-Host "Importing license file"
+        Import-NAVServerLicense -LicenseFile $licenseFilePath -ServerInstance $ServerInstance -Database NavDatabase -WarningAction SilentlyContinue
+    }
+    elseif (Test-Path "$navDvdPath\SQLDemoDatabase\$CommonAppData\Microsoft\Microsoft Dynamics NAV\*\Database\cronus.flf") {
+        Write-Host "Importing CRONUS license file"
+        $licensefile = (Get-Item -Path "$navDvdPath\SQLDemoDatabase\$CommonAppData\Microsoft\Microsoft Dynamics NAV\*\Database\cronus.flf").FullName
+        Import-NAVServerLicense -LicenseFile $licensefile -ServerInstance $ServerInstance -Database NavDatabase -WarningAction SilentlyContinue
+    }
+
+    if ($multitenant) {
+        Copy-NavDatabase -SourceDatabaseName "tenant" -DestinationDatabaseName "default"
+        Write-Host "Mounting tenant database"
+        Mount-NavDatabase -ServerInstance $ServerInstance -TenantId "default" -DatabaseName "default"
+        $mtstartTime = [DateTime]::Now
+        while ([DateTime]::Now.Subtract($mtstartTime).TotalSeconds -le 60) {
+            $tenantInfo = Get-NAVTenant -ServerInstance $ServerInstance -Tenant "default"
+            if ($tenantInfo.State -eq "Operational") { break }
+            Start-Sleep -Seconds 1
+        }
+        Write-Host "Tenant is $($TenantInfo.State)"
+    }
+
+    if ($installApps) {
+        $installApps | ForEach-Object {
+            $appFile = $_
+            $navAppInfo = Get-NAVAppInfo -Path $appFile
+            $appPublisher = $navAppInfo.Publisher
+            $appName = $navAppInfo.Name
+            $appVersion = $navAppInfo.Version
+            $syncAndInstall = $true
+            $tenantAppInfo = Get-NAVAppInfo -ServerInstance $serverInstance -Name $appName -Publisher $appPublisher -Version $appVersion -tenant default -tenantSpecificProperties
+            if ($tenantAppInfo) {
+                if ($tenantAppInfo.IsInstalled) {
+                    Write-Host "Skipping $appName as it is already installed"
+                    $syncAndInstall = $false
+                }
+                else {
+                    Write-Host "$appName is already published"
+                }
+            }
+            else {
+                Write-Host "Publishing $appFile"
+                Publish-NavApp -ServerInstance $ServerInstance -Path $appFile -SkipVerification
+            }
+            if ($syncAndInstall) {    
+                Write-Host "Synchronizing $appName"
+                Sync-NavTenant -ServerInstance $ServerInstance -Tenant default -Force
+                Sync-NavApp -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant default -Mode ForceSync -force -WarningAction Ignore
+                Write-Host "Installing $appName"
+                Install-NavApp -ServerInstance $ServerInstance -Publisher $appPublisher -Name $appName -Version $appVersion -Tenant default
+            }
+        }
+    }
+    
+    Write-Host "Stopping Business Central Service Tier"
+    Stop-Service -Name $NavServiceName -WarningAction Ignore
+}
+
+$timespend = [Math]::Round([DateTime]::Now.Subtract($startTime).Totalseconds)
+Write-Host "Installation took $timespend seconds"
+Write-Host "Installation complete"

--- a/generic/Run/GetDvdArtifactPaths.ps1
+++ b/generic/Run/GetDvdArtifactPaths.ps1
@@ -1,0 +1,142 @@
+<#
+.SYNOPSIS
+Gets the path to the server's W1DVD Service folder
+.DESCRIPTION
+Gets the path to the server's W1DVD Service folder
+#>
+function Get-NavDvdServiceFolder([string]$platformArtifactPath)
+{
+    if ($platformArtifactPath -eq $null -or $platformArtifactPath.Count -eq 0)
+    {
+        Throw "The path to the platform artifact is not specified."
+    }
+
+    $ServiceFolder = Join-Path -Resolve $platformArtifactPath "ServiceTier\pfiles64\Microsoft Dynamics NAV\*\Service" -ErrorAction Ignore
+    if (($null -eq $ServiceFolder) -or !(Test-Path $ServiceFolder))
+    {
+        # Use the legacy folder path used before version 27 (wix 6.0)
+        $ServiceFolder = Join-Path -Resolve  $platformArtifactPath "ServiceTier\program files\Microsoft Dynamics NAV\*\Service" -ErrorAction Ignore
+    }
+
+    return $ServiceFolder
+}
+
+<#
+.SYNOPSIS
+Gets the name of the Common App Data folder on the dvd image
+.DESCRIPTION
+Gets the name of the Common App Data folder on the dvd image
+#>
+function Get-WixCommonAppData([string]$platformArtifactPath)
+{
+    if ($platformArtifactPath -eq $null -or $platformArtifactPath.Count -eq 0)
+    {
+        Throw "The path to the platform artifact is not specified."
+    }
+
+    $ServiceFolder = Join-Path -Resolve $platformArtifactPath "ServiceTier\pfiles64\Microsoft Dynamics NAV\*\Service" -ErrorAction Ignore
+    $CommonAppData = "CommApp"
+    if (($null -eq $ServiceFolder) -or !(Test-Path $ServiceFolder))
+    {
+        # Use the legacy folder path used before version 27 (wix 6.0)
+        $CommonAppData = "CommonAppData"
+    }
+
+    return $CommonAppData
+}
+
+<#
+.SYNOPSIS
+Gets the name of the Program Files folder on the dvd image
+.DESCRIPTION
+Gets the name of the Program Files folder on the dvd image
+#>
+function Get-WixProgramFiles64([string]$platformArtifactPath)
+{
+    if ($platformArtifactPath -eq $null -or $platformArtifactPath.Count -eq 0)
+    {
+        Throw "The path to the platform artifact is not specified."
+    }
+
+    $ServiceFolder = Join-Path -Resolve $platformArtifactPath "ServiceTier\pfiles64\Microsoft Dynamics NAV\*\Service" -ErrorAction Ignore
+    $pfiles64 = "pfiles64"
+    if (($null -eq $ServiceFolder) -or !(Test-Path $ServiceFolder))
+    {
+        # Use the legacy folder path used before version 27 (wix 6.0)
+        $pfiles64 = "program files"
+    }
+
+    return $pfiles64
+}
+
+<#
+.SYNOPSIS
+Gets the path to the DevTools W1DVD folder
+.DESCRIPTION
+Gets the path to the DevTools W1DVD folder
+#>
+function Get-NavDvdDevToolsFolder([string]$platformArtifactPath)
+{
+    if ($platformArtifactPath -eq $null -or $platformArtifactPath.Count -eq 0)
+    {
+        Throw "The path to the platform artifact is not specified."
+    }
+
+    $rootPath = Join-Path $platformArtifactPath "ModernDev\pfiles" -ErrorAction Ignore
+    if (($null -eq $rootPath) -or !(Test-Path $rootPath))
+    {
+        # Use the legacy folder path used before version 27 and wix 6.0
+        $rootPath = Join-Path $platformArtifactPath "ModernDev\program files" -ErrorAction Ignore
+    }
+
+    $platformPath = Join-Path -Resolve $rootPath "Microsoft Dynamics NAV" -ErrorAction Ignore
+
+    Return "$platformPath"
+}
+
+<#
+.SYNOPSIS
+Gets the path to the WebClient W1DVD folder
+.DESCRIPTION
+Gets the path to the WebClient W1DVD folder
+#>
+function Get-NavDvdWebClientFolder([string]$platformArtifactPath)
+{
+    if ($platformArtifactPath -eq $null -or $platformArtifactPath.Count -eq 0)
+    {
+        Throw "The path to the platform artifact is not specified."
+    }
+
+    $WebRoot = Join-Path $platformArtifactPath "WebClient\pfiles\Microsoft Dynamics NAV"
+    $webClientFolder = Join-Path -Resolve $WebRoot "*\Web Client" -ErrorAction Ignore
+    if (($null -eq $webClientFolder) -or !(Test-Path $webClientFolder))
+    {
+        # Use the legacy folder path used before version 27 and wix 6.0
+        $WebRoot = Join-Path $platformArtifactPath "WebClient\Microsoft Dynamics NAV"        
+    }
+
+    return $WebRoot
+}
+
+<#
+.SYNOPSIS
+Gets the path to the NavSip component on the W1DVD
+.DESCRIPTION
+Gets the path to the NavSip component on the W1DVD
+#>
+function Get-NavDvdSipComponentPath([string]$platformArtifactPath)
+{
+    if ($platformArtifactPath -eq $null -or $platformArtifactPath.Count -eq 0)
+    {
+        Throw "The path to the platform artifact is not specified."
+    }
+
+    $sipComponent = Join-Path $platformArtifactPath "ServiceTier\System64\NavSip.dll" -ErrorAction Ignore
+    if (($null -eq $sipComponent) -or !(Test-Path $sipComponent))
+    {
+        # Use the legacy folder path used before version 27 and wix 6.0
+        $sipComponent = Join-Path $platformArtifactPath "ServiceTier\System64Folder\NavSip.dll"
+    }
+
+    return $sipComponent
+}

--- a/generic/Run/start.ps1
+++ b/generic/Run/start.ps1
@@ -70,6 +70,7 @@ Add-Type -TypeDefinition $Source -Language CSharp -WarningAction SilentlyContinu
 [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
 . (Get-MyFilePath "HelperFunctions.ps1")
+. (Get-MyFilePath "GetDvdArtifactPaths.ps1")
 
 if (!$multitenant) {
     $multitenant = ($env:multitenant -eq "Y")
@@ -157,7 +158,7 @@ try {
                     $mtParam = @{}
                     $versionFolder = $env:installfolder
                     if (!($versionFolder)) {
-                        $setupVersion = (Get-Item -Path (Join-Path $platformArtifactPath "ServiceTier\program files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Server.exe")).VersionInfo.FileVersion
+                        $setupVersion = (Get-Item -Path (Join-Path (Get-NavDvdServiceFolder $platformArtifactPath) "Microsoft.Dynamics.Nav.Server.exe")).VersionInfo.FileVersion
                         $versionNo = [Int]::Parse($setupVersion.Split('.')[0]+$setupVersion.Split('.')[1])
                         $versionFolder = ""
 
@@ -321,7 +322,7 @@ try {
                 }
             }
             elseif (Test-Path $navDvdPath -PathType Container) {
-                $setupVersion = (Get-Item -Path "$navDvdPath\ServiceTier\program files\Microsoft Dynamics NAV\*\Service\Microsoft.Dynamics.Nav.Server.exe").VersionInfo.FileVersion
+                $setupVersion = (Get-Item -Path (Join-Path (Get-NavDvdServiceFolder $platformArtifactPath) "Microsoft.Dynamics.Nav.Server.exe")).VersionInfo.FileVersion
                 $versionNo = [Int]::Parse($setupVersion.Split('.')[0]+$setupVersion.Split('.')[1])
                 $versionFolder = ""
                 Get-ChildItem -Path "C:\Run" -Directory | where-object { [Int]::TryParse($_.Name, [ref]$null) } | % { [Int]::Parse($_.Name) } | Sort-Object | % {


### PR DESCRIPTION
The DVD image for BC version 2.7 is created with WIX 6, and uses tokenized names for standard folders. All relevant scripts has been modified to use functions for path names related to the DVD image. The functions will evaluate the current layout and return the correct root path for the uncompressed files.
The 270 subfolder is based on the existing 260 folder with the addition of path functions.