### PR TITLE
Return Sip component folder rather than full path

### DIFF
--- a/generic/Run/GetDvdArtifactPaths.ps1
+++ b/generic/Run/GetDvdArtifactPaths.ps1
@@ -118,10 +118,10 @@ function Get-NavDvdSipComponentPath {
         [string] $platformArtifactPath
     )
 
-    $sipComponent = Join-Path $platformArtifactPath "ServiceTier\System64\NavSip.dll"
-    if (!(Test-Path $sipComponent)) {
+    $sipComponentPath = Join-Path $platformArtifactPath "ServiceTier\System64"
+    if (!(Test-Path $sipComponentPath)) {
         # Use the legacy folder path used before version 27 and wix 6.0
-        $sipComponent = Join-Path $platformArtifactPath "ServiceTier\System64Folder\NavSip.dll"
+        $sipComponent = Join-Path $platformArtifactPath "ServiceTier\System64Folder"
     }
 
     return $sipComponent

--- a/generic/Run/GetDvdArtifactPaths.ps1
+++ b/generic/Run/GetDvdArtifactPaths.ps1
@@ -121,8 +121,8 @@ function Get-NavDvdSipComponentPath {
     $sipComponentPath = Join-Path $platformArtifactPath "ServiceTier\System64"
     if (!(Test-Path $sipComponentPath)) {
         # Use the legacy folder path used before version 27 and wix 6.0
-        $sipComponent = Join-Path $platformArtifactPath "ServiceTier\System64Folder"
+        $sipComponentPath = Join-Path $platformArtifactPath "ServiceTier\System64Folder"
     }
 
-    return $sipComponent
+    return $sipComponentPath
 }


### PR DESCRIPTION
The output of Get-NavDvdSipComponentPath is used as the source path during robocopy. However, robocopy expect a folder and not the path to a file. 

```
 ERROR 267 (0x0000010B) Accessing Source Directory C:\dl\sandbox\27.0.34360.0\platform\ServiceTier\System64\NavSip.dll\
The directory name is invalid.
```