### PR TITLE
Add support for platformArtifactUrl

### DIFF
--- a/generic/Run/HelperFunctions.ps1
+++ b/generic/Run/HelperFunctions.ps1
@@ -676,6 +676,7 @@ function Download-Artifacts {
         [Parameter(Mandatory=$true)]
         [string] $artifactUrl,
         [switch] $includePlatform,
+        [string] $platformArtifactUrl = "",
         [switch] $force,
         [switch] $forceRedirection,
         [string] $basePath = 'c:\dl'
@@ -729,7 +730,11 @@ function Download-Artifacts {
     $appArtifactPath
 
     if ($includePlatform) {
-        if ($appManifest.PSObject.Properties.name -eq "platformUrl") {
+        if ($platformArtifactUrl) {
+            Write-Host "Using separate platformArtifactUrl $($platformArtifactUrl.split('?')[0])"
+            $platformUrl = $platformArtifactUrl
+        }
+        elseif ($appManifest.PSObject.Properties.name -eq "platformUrl") {
             $platformUrl = $appManifest.platformUrl
         }
         else {

--- a/generic/Run/start.ps1
+++ b/generic/Run/start.ps1
@@ -31,7 +31,7 @@ if (!$filesOnly) {
 $myStart = Join-Path $myPath "start.ps1"
 if ($PSCommandPath -ne $mystart) {
     if (Test-Path -Path $myStart) {
-        . $myStart -installOnly:$installOnly -filesOnly:$filesOnly -multitenant:$multitenant -artifactUrl $artifactUrl -platformArtifactUrl $platformArtifactUrl -includeTestToolkit:$includeTestToolkit -includeTestLibrariesOnly:$includeTestLibrariesOnly -includeTestFrameworkOnly:$includeTestFrameworkOnly -includePerformanceToolkit:$includePerformanceToolkit
+        . $myStart -installOnly:$installOnly -filesOnly:$filesOnly -multitenant:$multitenant -artifactUrl $artifactUrl -includeTestToolkit:$includeTestToolkit -includeTestLibrariesOnly:$includeTestLibrariesOnly -includeTestFrameworkOnly:$includeTestFrameworkOnly -includePerformanceToolkit:$includePerformanceToolkit
         exit
     }
 }

--- a/generic/Run/start.ps1
+++ b/generic/Run/start.ps1
@@ -3,6 +3,7 @@ Param(
     [switch] $filesOnly,
     [switch] $multitenant,
     [string] $artifactUrl = "",
+    [string] $platformArtifactUrl = "",
     [switch] $includeTestToolkit,
     [switch] $includeTestLibrariesOnly,
     [switch] $includeTestFrameworkOnly,
@@ -30,7 +31,7 @@ if (!$filesOnly) {
 $myStart = Join-Path $myPath "start.ps1"
 if ($PSCommandPath -ne $mystart) {
     if (Test-Path -Path $myStart) {
-        . $myStart -installOnly:$installOnly -filesOnly:$filesOnly -multitenant:$multitenant -artifactUrl $artifactUrl -includeTestToolkit:$includeTestToolkit -includeTestLibrariesOnly:$includeTestLibrariesOnly -includeTestFrameworkOnly:$includeTestFrameworkOnly -includePerformanceToolkit:$includePerformanceToolkit
+        . $myStart -installOnly:$installOnly -filesOnly:$filesOnly -multitenant:$multitenant -artifactUrl $artifactUrl -platformArtifactUrl $platformArtifactUrl -includeTestToolkit:$includeTestToolkit -includeTestLibrariesOnly:$includeTestLibrariesOnly -includeTestFrameworkOnly:$includeTestFrameworkOnly -includePerformanceToolkit:$includePerformanceToolkit
         exit
     }
 }
@@ -150,7 +151,11 @@ try {
 
                     Write-Host "Using artifactUrl $($artifactUrl.split('?')[0])"
 
-                    $artifactPaths = Download-Artifacts -artifactUrl $artifactUrl -includePlatform
+                    if (!$platformArtifactUrl) {
+                        $platformArtifactUrl = "$env:platformArtifactUrl"
+                    }
+
+                    $artifactPaths = Download-Artifacts -artifactUrl $artifactUrl -includePlatform -platformArtifactUrl $platformArtifactUrl
                     $appArtifactPath = $artifactPaths[0]
                     $platformArtifactPath = $artifactPaths[1]
 


### PR DESCRIPTION
When creating a container for a specific application version, the used platform version is fixed.

This PR aims to decouple the application and platform version.