### PR TITLE
Fix markstale.ps1 Digests parameter type from string to string[]

### DIFF
--- a/build/markstale.ps1
+++ b/build/markstale.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory = $true)]
-    [string]$Digests, # $digests = $env:digestsJson | ConvertFrom-Json
+    [string[]]$Digests, # $digests = $env:digestsJson | ConvertFrom-Json
     [Parameter(Mandatory = $false)]
     [string]$PushRegistry = "mcrbusinesscentral.azurecr.io"
 )


### PR DESCRIPTION
## Problem

The `MarkOldImagesStale` job in the "Build new images" workflow is failing ([run #695](https://github.com/microsoft/nav-docker/actions/runs/24763865306/job/72462802665)).

The `$Digests` parameter in `markstale.ps1` is declared as `[string]`, but both callers pass an array:

- `BuildMissingImages.yaml`: `$digests = $env:digestsJson | ConvertFrom-Json` (produces `string[]`)
- `MarkStale.yaml`: `$digests = "$env:digests".Split(",").Trim() | Select-Object -Unique` (produces `string[]`)

PowerShell coerces the array into a single space-joined string (e.g. `"sha256:abc sha256:def"`), so the `foreach` loop iterates once with a malformed digest, causing `oras attach` to fail.

## Fix

Change the parameter type from `[string]` to `[string[]]` so the array is preserved and each digest is processed individually.