### PR TITLE
Install oras CLI in markstale.ps1 instead of throwing

### DIFF
--- a/build/markstale.ps1
+++ b/build/markstale.ps1
@@ -6,7 +6,13 @@ param(
 )
 
 if (-not (Get-Command -name "oras" -ErrorAction SilentlyContinue)) {
-    throw "Please install the ORAS CLI before running this script e.g. via 'winget install oras-cli' or 'choco install oras-cli'"
+    $version = "1.2.0"
+    $filename = Join-Path $env:TEMP "oras_$($version)_windows_amd64.zip"
+    $orasPath = Join-Path $env:TEMP "oras"
+    Write-Host "Installing ORAS CLI v$version..."
+    Invoke-RestMethod -Method GET -UseBasicParsing -Uri "https://github.com/oras-project/oras/releases/download/v$($version)/oras_$($version)_windows_amd64.zip" -OutFile $filename
+    Expand-Archive -Path $filename -DestinationPath $orasPath -Force
+    $env:PATH = "$orasPath;$env:PATH"
 }
 
 az acr login --name $PushRegistry


### PR DESCRIPTION
## Problem

The `MarkOldImagesStale` job in the "Build new images" workflow ([run #696](https://github.com/microsoft/nav-docker/actions/runs/24833077792)) is failing because `markstale.ps1` expects `oras` to be pre-installed on the runner, but GitHub Actions runners don't have it.

This was introduced in commit 30b381c which refactored the inline workflow code into `build/markstale.ps1`. The old workflow code downloaded oras on-the-fly, but the new script just throws an error if oras isn't found.

## Fix

Instead of throwing when `oras` is not found, download and install it automatically (matching the original behavior).