### PR TITLE
Move ACR login before docker build to prevent OIDC token expiry

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -87,6 +87,11 @@ function Get-OsVersion {
 }
 
 try {
+    # Login to ACR early, before the lengthy docker build, to avoid OIDC token expiry
+    if ($PushToDev -or $PushToProd) {
+        az acr login --name $PushRegistry
+    }
+
     Push-Location "generic"
     $rootPath = Get-Location
 
@@ -146,7 +151,6 @@ if ($PushToDev -or $PushToProd) {
         )
     }
     
-    az acr login --name $PushRegistry
     $newtags | ForEach-Object {
         Write-Host "Pushing $image with tag $_"
         docker tag $image $_


### PR DESCRIPTION
## Problem

After the refactor in 30b381c, the `az acr login` call in `build.ps1` was placed **after** the `docker build` step. Since `docker build --isolation=hyperv` takes 20+ minutes, the Azure OIDC token obtained in the `Az CLI login` workflow step expires before `az acr login` runs, causing `AADSTS700024: Client assertion is not within its valid time range` errors.

Example failure: https://github.com/microsoft/nav-docker/actions/runs/24763865306/job/72685414265

## Fix

Move `az acr login` to the **beginning** of the script (before `docker pull` and `docker build`), matching the original inline behavior. The Docker registry credential obtained by `az acr login` persists long enough for the push operation after the build.