### PR TITLE
Install SqlServer module via Windows PowerShell and verify load in pwsh 7

### DIFF
--- a/generic/Run/SetupGeneric2.ps1
+++ b/generic/Run/SetupGeneric2.ps1
@@ -3,7 +3,16 @@ Write-Host "only24=$env:only24"
 $filesonly = $env:filesonly -eq 'true'
 $only24 = $env:only24 -eq 'true'
 if (-not $filesonly) {
-    Write-Host 'Installing SqlServer Module in PowerShell 7'
-    pwsh -Command 'Install-Module -Name SqlServer -RequiredVersion 22.2.0 -Scope AllUsers -Force'
+    Write-Host 'Installing SqlServer Module in Windows PowerShell'
+    Install-PackageProvider -Name NuGet -Force -Scope AllUsers | Out-Null
+    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+    Install-Module -Name SqlServer -RequiredVersion 22.2.0 -Scope AllUsers -Force -AllowClobber
+
+    Write-Host 'Verifying SqlServer module loads in PowerShell 7'
+    pwsh -NoProfile -Command 'Import-Module -Name SqlServer -RequiredVersion 22.2.0 -ErrorAction Stop'
+    if ($LASTEXITCODE -ne 0) {
+        throw "SqlServer module 22.2.0 failed to import in PowerShell 7 (pwsh exit $LASTEXITCODE)"
+    }
+
     Write-Host 'Done'
 }


### PR DESCRIPTION
**Problem**
Currently the SqlServer module is quietly failing to install on all our non-v2025 images. It doesn't appear to be due to a problem in the module itself but rather with the install-module on PowerShell 7.6 

**Fix**
Change the way we do installs of SqlServer so we run the install on Powershell 5 and verify the install after on pwsh. 