### PR TITLE
Revert "Install SqlServer module via Windows PowerShell and verify load in pwsh 7 (#606)"

### DIFF
--- a/generic/Run/SetupGeneric2.ps1
+++ b/generic/Run/SetupGeneric2.ps1
@@ -3,16 +3,7 @@ Write-Host "only24=$env:only24"
 $filesonly = $env:filesonly -eq 'true'
 $only24 = $env:only24 -eq 'true'
 if (-not $filesonly) {
-    Write-Host 'Installing SqlServer Module in Windows PowerShell'
-    Install-PackageProvider -Name NuGet -Force -Scope AllUsers | Out-Null
-    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
-    Install-Module -Name SqlServer -RequiredVersion 22.2.0 -Scope AllUsers -Force -AllowClobber
-
-    Write-Host 'Verifying SqlServer module loads in PowerShell 7'
-    pwsh -NoProfile -Command 'Import-Module -Name SqlServer -RequiredVersion 22.2.0 -ErrorAction Stop'
-    if ($LASTEXITCODE -ne 0) {
-        throw "SqlServer module 22.2.0 failed to import in PowerShell 7 (pwsh exit $LASTEXITCODE)"
-    }
-
+    Write-Host 'Installing SqlServer Module in PowerShell 7'
+    pwsh -Command 'Install-Module -Name SqlServer -RequiredVersion 22.2.0 -Scope AllUsers -Force'
     Write-Host 'Done'
 }


### PR DESCRIPTION
Reverts cb8ce01 (#606).

That change broke the ltsc2016 image build. `Install-PackageProvider -Name NuGet` fails on Server 2016 / Windows PowerShell 5.1 because the default `[Net.ServicePointManager]::SecurityProtocol` is TLS 1.0/1.1, while PSGallery and the NuGet provider bootstrap endpoint require TLS 1.2+:

```
Installing SqlServer Module in Windows PowerShell
WARNING: MSG:UnableToDownload
... NoMatchFoundForProvider, ...InstallPackageProvider
The command 'powershell -Command ... .\Run\SetupGeneric2.ps1' returned a non-zero code: 1
Error building image
```

Failing run: https://github.com/microsoft/nav-docker/actions/runs/25359575665/job/74366426200

Reverting to unblock the build pipeline. We'll re-roll a fixed version that enables TLS 1.2 before the install (and keeps the pwsh-side verification) in a follow-up PR.