### PR TITLE
Install SqlServer module via Save-Module to pwsh-only modules path

### DIFF
--- a/generic/Run/SetupGeneric2.ps1
+++ b/generic/Run/SetupGeneric2.ps1
@@ -3,7 +3,27 @@ Write-Host "only24=$env:only24"
 $filesonly = $env:filesonly -eq 'true'
 $only24 = $env:only24 -eq 'true'
 if (-not $filesonly) {
-    Write-Host 'Installing SqlServer Module in PowerShell 7'
-    pwsh -Command 'Install-Module -Name SqlServer -RequiredVersion 22.2.0 -Scope AllUsers -Force'
+    Write-Host 'Installing SqlServer Module to PowerShell 7 modules path'
+    # Server 2016 WinPS 5.1 defaults to TLS 1.0/1.1; PSGallery requires TLS 1.2+.
+    [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+    Install-PackageProvider -Name NuGet -Force -Scope AllUsers | Out-Null
+    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+
+    # Save to the pwsh-only modules path so PS 5.1 keeps resolving Invoke-Sqlcmd to SQLPS
+    # (avoids SqlServer 22's strict-SSL defaults breaking in-container localhost SQL connections).
+    # Running from Windows PS 5.1 also avoids the pwsh 7.6 PowerShellGet AV crash on Server 2022.
+    $pwshModulesPath = 'C:\Program Files\PowerShell\Modules'
+    if (-not (Test-Path $pwshModulesPath)) {
+        New-Item -ItemType Directory -Path $pwshModulesPath -Force | Out-Null
+    }
+    Save-Module -Name SqlServer -RequiredVersion 22.2.0 -Path $pwshModulesPath -Force
+
+    Write-Host 'Verifying SqlServer module loads in PowerShell 7'
+    pwsh -NoProfile -Command 'Import-Module -Name SqlServer -RequiredVersion 22.2.0 -ErrorAction Stop'
+    if ($LASTEXITCODE -ne 0) {
+        throw "SqlServer module 22.2.0 failed to import in PowerShell 7 (pwsh exit $LASTEXITCODE)"
+    }
+
     Write-Host 'Done'
 }

--- a/generic/Run/SetupGeneric2.ps1
+++ b/generic/Run/SetupGeneric2.ps1
@@ -4,15 +4,12 @@ $filesonly = $env:filesonly -eq 'true'
 $only24 = $env:only24 -eq 'true'
 if (-not $filesonly) {
     Write-Host 'Installing SqlServer Module to PowerShell 7 modules path'
-    # Server 2016 WinPS 5.1 defaults to TLS 1.0/1.1; PSGallery requires TLS 1.2+.
     [Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
     Install-PackageProvider -Name NuGet -Force -Scope AllUsers | Out-Null
     Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
     # Save to the pwsh-only modules path so PS 5.1 keeps resolving Invoke-Sqlcmd to SQLPS
-    # (avoids SqlServer 22's strict-SSL defaults breaking in-container localhost SQL connections).
-    # Running from Windows PS 5.1 also avoids the pwsh 7.6 PowerShellGet AV crash on Server 2022.
     $pwshModulesPath = 'C:\Program Files\PowerShell\Modules'
     if (-not (Test-Path $pwshModulesPath)) {
         New-Item -ItemType Directory -Path $pwshModulesPath -Force | Out-Null


### PR DESCRIPTION
Install the `SqlServer` module via `Save-Module` into `C:\Program Files\PowerShell\Modules` (pwsh-only path) instead of `pwsh -Command 'Install-Module …'`.

Why:
- Avoids the pwsh 7.6 PowerShellGet AV crash on Server 2022 by running the install under Windows PowerShell 5.1.
- Targets the pwsh-only modules path, so PS 5.1 keeps resolving `Invoke-Sqlcmd` to the existing SQLPS 16 — preserves the historical "two worlds" split and avoids SqlServer 22's strict-SSL defaults breaking in-container localhost SQL connections.
- pwsh 7 still gets `SqlServer 22.2.0` (verified via `Import-Module` post-install).

Verified locally with `New-BcContainer` against freshly built ltsc2019, ltsc2022, and ltsc2025 generic images — all reach "Ready for connections!" and pass `Set SQL Server memory limit`.