### PR TITLE
Fix New-BcImage -includeTestToolkit on BC v29 (Get-NAVAppInfo not recognized)

### DIFF
--- a/generic/Run/270/navinstall.ps1
+++ b/generic/Run/270/navinstall.ps1
@@ -175,6 +175,11 @@ catch {
     Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Management.psm1"
 }
 
+$appsManagementModule = Join-Path $serviceTierFolder 'Admin\Microsoft.BusinessCentral.Apps.Management.psd1'
+if (Test-Path $appsManagementModule) {
+    Import-Module $appsManagementModule -WarningAction SilentlyContinue
+}
+
 $databaseServer = "localhost"
 $databaseInstance = "SQLEXPRESS"
 if ($multitenant) {


### PR DESCRIPTION
## Why

`New-BcImage -includeTestToolkit` fails during image build on current BC v29 platform builds with `The term 'Get-NAVAppInfo' is not recognized`, leading to `Installation failed`. Building without the test toolkit works because that code path never calls the app cmdlets. This is the nav-docker equivalent of navcontainerhelper #4164.

## Root cause

On current v29 platform builds the app-management cmdlets (`Get-NAVAppInfo`, `Publish-NAVApp`, `Sync-NAVApp`, `Install-NAVApp`, `Uninstall-NAVApp`, `Unpublish-NAVApp`) are no longer exported by the classic `Microsoft.Dynamics.Nav.Management` module. They now live only in the separate `Microsoft.BusinessCentral.Apps.Management` module. `generic/Run/270/navinstall.ps1` imported only `Microsoft.Dynamics.Nav.Management.psm1`, so on v29 the test-toolkit publish loop calls cmdlets that aren't loaded and the build fails. The running-container path (`Prompt.ps1`) already imports the Apps.Management module under PowerShell 7; `navinstall.ps1` (which runs under Windows PowerShell 5.1) was not updated.

## The fix

Add a guarded import of the `Microsoft.BusinessCentral.Apps.Management` module immediately after the existing `Microsoft.Dynamics.Nav.Management.psm1` import in `generic/Run/270/navinstall.ps1`.

Two important details, both verified against real installed v29 artifacts:

- Import the `.psd1` manifest, not the `.dll`. The `Microsoft.BusinessCentral.Apps.Management.dll` is a .NET 10 assembly that fails to load under Windows PowerShell 5.1 (`Could not load file or assembly 'System.Runtime, Version=10.0.0.0'`). navinstall.ps1 runs under Windows PowerShell 5.1. The `.psd1` declares `CompatiblePSEditions = Desktop, Core` and loads cleanly in both PS 5.1 and PS 7.
- The `Test-Path` guard makes this a harmless no-op on older platforms whose classic module still bundles these cmdlets, so it is safe across the range of builds the 270 image serves.

## Scope

Only `generic/Run/270/navinstall.ps1` is changed, since v29 routes to `C:\Run\270`. The 260/240 variants build on pre-split platforms where the classic module still bundles the app cmdlets, so they are not affected today.