### PR TITLE
Revert "Fix New-BcImage -includeTestToolkit on BC v29 (#611)"

### DIFF
--- a/generic/Run/270/navinstall.ps1
+++ b/generic/Run/270/navinstall.ps1
@@ -175,11 +175,6 @@ catch {
     Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Management.psm1"
 }
 
-$appsManagementModule = Join-Path $serviceTierFolder 'Admin\Microsoft.BusinessCentral.Apps.Management.psd1'
-if (Test-Path $appsManagementModule) {
-    Import-Module $appsManagementModule -WarningAction SilentlyContinue
-}
-
 $databaseServer = "localhost"
 $databaseInstance = "SQLEXPRESS"
 if ($multitenant) {


### PR DESCRIPTION
Reverts #611.

## Why

After #611 shipped (guarded import of `Microsoft.BusinessCentral.Apps.Management.psd1` in `generic/Run/270/navinstall.ps1`), a new failure was reported that appears to be caused by that import:

- microsoft/AL-Go#2325: container creation for PR / CI-CD pipelines fails at `Importing PowerShell Modules` with:
  `Could not load file or assembly 'System.Runtime, Version=8.0.0.0, ...'` at `C:\Run\navinstall.ps1: line 180` (the added import block).

This reproduces on artifacts that previously worked (e.g. sandbox `28.3.52162.52774`), and notably without `-includeTestToolkit` -- i.e. the new import runs and fails even when the app cmdlets aren't needed, breaking a much broader set of scenarios than the original #611 bug.

## What this does

Reverts the 5-line addition from #611 to restore the previous module-import behavior and unblock the affected pipelines while the root cause is investigated.

## Follow-up

The original #611 problem (`Get-NAVAppInfo` not recognized on post-split BC v29 builds) still needs a proper fix that does not regress the `System.Runtime` load path seen in AL-Go#2325. Investigation to follow.