### PR TITLE
Import Apps.Management only when app cmdlets are missing (BC v29)

### DIFF
--- a/generic/Run/270/navinstall.ps1
+++ b/generic/Run/270/navinstall.ps1
@@ -175,6 +175,23 @@ catch {
     Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Management.psm1"
 }
 
+# On newer BC platforms the app-management cmdlets (Get-NAVAppInfo, Publish/Sync/Install-NAVApp, ...)
+# were split out of the classic module above into Microsoft.BusinessCentral.Apps.Management. Only import
+# it when those cmdlets are actually missing: on older platforms the classic module still exports them and
+# that module's manifest is backed by a .NET assembly that cannot load under Windows PowerShell 5.1, so
+# importing it there aborts the install (see AL-Go issue 2325).
+if (-not (Get-Command Get-NAVAppInfo -ErrorAction SilentlyContinue)) {
+    $appsManagementModule = Join-Path $serviceTierFolder 'Admin\Microsoft.BusinessCentral.Apps.Management.psd1'
+    if (Test-Path $appsManagementModule) {
+        try {
+            Import-Module $appsManagementModule -WarningAction SilentlyContinue
+        }
+        catch {
+            Write-Host "Warning: Could not import '$appsManagementModule': $($_.Exception.Message)"
+        }
+    }
+}
+
 $databaseServer = "localhost"
 $databaseInstance = "SQLEXPRESS"
 if ($multitenant) {

--- a/generic/Run/270/navinstall.ps1
+++ b/generic/Run/270/navinstall.ps1
@@ -175,11 +175,6 @@ catch {
     Import-Module "$serviceTierFolder\Microsoft.Dynamics.Nav.Management.psm1"
 }
 
-$appsManagementModule = Join-Path $serviceTierFolder 'Admin\Microsoft.BusinessCentral.Apps.Management.psd1'
-if (Test-Path $appsManagementModule) {
-    Import-Module $appsManagementModule -WarningAction SilentlyContinue
-}
-
 $databaseServer = "localhost"
 $databaseInstance = "SQLEXPRESS"
 if ($multitenant) {


### PR DESCRIPTION
Re-does the BC v29 `Get-NAVAppInfo` fix from #611 in a way that does not regress older platforms. Companion to the revert in #612.

## Background

#611 fixed `New-BcImage -includeTestToolkit` failing on post-split BC v29 builds (`Get-NAVAppInfo` not recognized) by importing `Microsoft.BusinessCentral.Apps.Management` in `generic/Run/270/navinstall.ps1`. That import was unconditional (guarded only by `Test-Path`), and it broke a much wider set of scenarios:

- AL-Go#2325: on BC v28 artifacts, container creation fails at `Importing PowerShell Modules` with `Could not load file or assembly 'System.Runtime, Version=8.0.0.0'` -- even without `-includeTestToolkit`.

Root cause: the `Apps.Management.psd1` manifest is not the same across versions.

| Build | classic module exports `Get-NAVAppInfo` | `Apps.Management.psd1` under Windows PowerShell 5.1 |
| --- | --- | --- |
| v28.3 / v28.4 | yes | RootModule is the `.dll` (no `CompatiblePSEditions`) -> throws `System.Runtime` |
| v29 &lt; 52469 | yes | pure-PS (`CompatiblePSEditions = Desktop, Core`) -> loads fine |
| v29 &gt;= 52469 | no | pure-PS -> loads fine |

The only build that actually needs the import (52469+) is exactly the one where the classic module lacks the cmdlet and the manifest is PS 5.1 compatible. Every build where the import throws is one where the classic module already provides the cmdlet.

## The fix

Gate the import on a capability check: only import `Apps.Management` when `Get-NAVAppInfo` is not already available. Wrap it in try/catch so any future import failure logs a warning instead of aborting the install.

- v28 / early v29: classic module already exports the cmdlets, import is skipped -> no `System.Runtime` error (fixes AL-Go#2325).
- v29 52469+: cmdlets are missing and the manifest is PS 5.1 compatible, import runs and succeeds (fixes the original #611 bug).

## Validation

Verified under Windows PowerShell 5.1 against cached artifacts 28.3.52162, 28.4.52737, 29.0.51936, and 29.0.52469. Every build ends with `Get-NAVAppInfo` available and no `System.Runtime` load error.