### PR TITLE
Prefer pure-PowerShell BC admin modules in Prompt.ps1 for v29+

### DIFF
--- a/generic/Run/Prompt.ps1
+++ b/generic/Run/Prompt.ps1
@@ -17,7 +17,33 @@ if ($PSScriptRoot -eq "c:\run" -and (Test-Path "c:\run\my\prompt.ps1")) {
 }
 else {
     $serviceTierFolder = (Get-Item "C:\Program Files\Microsoft Dynamics NAV\*\Service").FullName
-    if ($isPsCore -and (Test-Path "$serviceTierFolder\Admin")) {
+    $adminFolder = Join-Path $serviceTierFolder 'Admin'
+    $bcMgmtPsd1  = Join-Path $adminFolder 'Microsoft.BusinessCentral.Management.psd1'
+    $bcAppsPsd1  = Join-Path $adminFolder 'Microsoft.BusinessCentral.Apps.Management.psd1'
+
+    # The pure-PowerShell admin modules ship from BC v29 onwards and work in BOTH
+    # Windows PowerShell 5.1 and PowerShell 7
+    $usePurePsModules = $false
+    if (Test-Path $bcMgmtPsd1) {
+        $platformVersion = [System.Version](Import-PowerShellDataFile $bcMgmtPsd1).ModuleVersion
+        $usePurePsModules = ($platformVersion.Major -ge 29)
+    }
+
+    if ($usePurePsModules) {
+        # Preferred path -- identical for PS 5.1 and PS 7, full cmdlet parity
+        ImportModule (Join-Path $adminFolder 'NAVWebClientManagement.psm1')
+        ImportModule $bcMgmtPsd1
+        ImportModule $bcAppsPsd1
+        if ($isPsCore) {
+            if (Test-Path 'c:\run\my\pscoreoverrides.ps1') {
+                . 'c:\run\my\pscoreoverrides.ps1'
+            }
+            elseif (Test-Path 'c:\run\pscoreoverrides.ps1') {
+                . 'c:\run\pscoreoverrides.ps1'
+            }
+        }
+    }
+    elseif ($isPsCore -and (Test-Path $adminFolder)) {
         ImportModule "$serviceTierFolder\Admin\Microsoft.Dynamics.Nav.Management.psm1"
         ImportModule "$serviceTierFolder\Admin\Microsoft.BusinessCentral.Management.psd1"
         ImportModule "$serviceTierFolder\Admin\Microsoft.BusinessCentral.Apps.Management.dll"

--- a/generic/Run/Prompt.ps1
+++ b/generic/Run/Prompt.ps1
@@ -31,7 +31,6 @@ else {
 
     if ($usePurePsModules) {
         # Preferred path -- identical for PS 5.1 and PS 7, full cmdlet parity
-        ImportModule (Join-Path $adminFolder 'NAVWebClientManagement.psm1')
         ImportModule $bcMgmtPsd1
         ImportModule $bcAppsPsd1
         if ($isPsCore) {

--- a/generic/Run/Prompt.ps1
+++ b/generic/Run/Prompt.ps1
@@ -25,8 +25,13 @@ else {
     # Windows PowerShell 5.1 and PowerShell 7
     $usePurePsModules = $false
     if (Test-Path $bcMgmtPsd1) {
-        $platformVersion = [System.Version](Import-PowerShellDataFile $bcMgmtPsd1).ModuleVersion
-        $usePurePsModules = ($platformVersion.Major -ge 29)
+        try {
+            $platformVersion = [System.Version](Import-PowerShellDataFile $bcMgmtPsd1).ModuleVersion
+            $usePurePsModules = ($platformVersion.Major -ge 29)
+        }
+        catch {
+            $usePurePsModules = $false
+        }
     }
 
     if ($usePurePsModules) {


### PR DESCRIPTION
## Why

The binary BC admin modules (`Microsoft.BusinessCentral.Apps.Management.dll` and friends) use a custom `NavAssemblyLoadContext` whose static constructor builds a `System.Runtime.Loader.AssemblyDependencyResolver`. In a WinRM-hosted PowerShell 7 runspace (`wsmprovhost`), corehost/hostpolicy is never initialized, so that load throws a `Microsoft.Data.SqlClient` type-init / "Hostpolicy must be initialized" error. The result: `Get-NAVAppInfo` and `Get-NavServerInstance` are unavailable in a PS7 remote session (see navcontainerhelper#4101). The old Windows PowerShell 5.1 branch never imported any Apps module either, so `Get-NAVAppInfo` was missing there too.

Starting with BC v29, Microsoft ships pure-PowerShell reimplementations of these admin modules with no .NET binary dependency. They load cleanly in both Windows PowerShell 5.1 and PowerShell 7, including remote/WinRM sessions, with full cmdlet parity.

## What changed

`generic/Run/Prompt.ps1` now selects the pure-PowerShell admin modules as the preferred, edition-independent import path (a top-level branch, not nested under the `$isPsCore` check). When they are present it imports `NAVWebClientManagement.psm1` plus the two BC `.psd1` modules for both PS 5.1 and PS 7, which restores `Get-NAVAppInfo` on both editions.

Detection reads `ModuleVersion` from `Microsoft.BusinessCentral.Management.psd1` and gates on `Major -ge 29`. A simple `Test-Path` on the psd1 name would be wrong, because same-named binary-backed psd1 files existed in v28 and early-preview v29 builds; the version check avoids that. The existing binary PS7 branch and the PS 5.1 legacy branch are preserved unchanged as fallbacks for older artifacts.

## Validation

Verified in a real WinRM-hosted PS7 runspace (`wsmprovhost`, PS 7.6) against a v29 container built from this change: the pure-PS modules import without error and both `Get-NavServerInstance` and `Get-NAVAppInfo` run successfully.

## Note for reviewers

This only changes the interactive/remote prompt import path. Getting navcontainerhelper to actually use a PS7 remote session (instead of falling back to `docker exec`) is a separate concern: the generic image does not register a `PowerShell.7` WinRM endpoint or an HTTPS 5986 listener out of the box. That is not addressed here.

Fixes https://github.com/microsoft/BCApps/issues/9720