### PR TITLE
Fix Windows Server 2019 image build by repairing StateRepository ACL

### DIFF
--- a/generic/Run/SetupGeneric1.ps1
+++ b/generic/Run/SetupGeneric1.ps1
@@ -1,5 +1,12 @@
 . (Join-Path $PSScriptRoot 'SetupUrls.ps1')
 
+# Workaround for Windows Server 2019 - see https://github.com/microsoft/dotnet-framework-docker/issues/1314
+if ([Environment]::OSVersion.Version.Build -eq 17763) {
+    Write-Host 'Repairing StateRepository ACL'
+    $q=[char]34; $n=[Environment]::NewLine; $k='MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModel\StateRepository\Cache'; $s='D:(A;;KR;;;IU)(A;;KR;;;SU)(A;OICIIO;GA;;;SY)(A;;KA;;;SY)(A;;KR;;;BA)(A;;KR;;;BU)(A;;KA;;;S-1-5-80-956008885-3418522649-1831038044-1853292631-2271478464)(A;;KR;;;AC)'; [IO.File]::WriteAllText('C:\f.inf','[Unicode]'+$n+'Unicode=yes'+$n+'[Version]'+$n+'signature='+$q+'$CHICAGO$'+$q+$n+'Revision=1'+$n+'[Registry Keys]'+$n+$q+$k+$q+',0,'+$q+$s+$q,[Text.Encoding]::Unicode); secedit /configure /db C:\f.sdb /cfg C:\f.inf /areas REGKEYS /quiet; Remove-Item C:\f.* -Force -EA 0; if(@((Get-Acl ('HKLM:\'+$k.Substring(8))).Access|Where-Object{-not $_.IsInherited}).Count -lt 8){throw 'StateRepository ACL repair failed'}
+    Write-Host 'Success'
+}
+
 Write-Host "FilesOnly=$env:filesOnly"
 Write-Host "only24=$env:only24"
 $filesonly = $env:filesonly -eq 'true'


### PR DESCRIPTION
Windows Server 2019 base images ship with incomplete ACLs on the `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModel\StateRepository\Cache` registry key. Installers that touch the AppModel StateRepository fail during the generic image build as a result, so ltsc2019 images cannot be produced. This is tracked upstream in https://github.com/microsoft/dotnet-framework-docker/issues/1314.

## Approach

The known workaround is normally applied as a `RUN` line in the Dockerfile, but that would apply it to every OS version we build. Instead this puts it at the top of `generic/Run/SetupGeneric1.ps1`, which the Dockerfile already dot-sources as its first `RUN` step. Same layer, same build-time context, but it can be gated at runtime on the OS build number:

```powershell
if ([Environment]::OSVersion.Version.Build -eq 17763) { ... }
```

ltsc2022 and ltsc2025 builds skip the block entirely, and neither `DOCKERFILE` nor `DOCKERFILE-filesonly` needed a change since both go through `SetupGeneric1.ps1`.

The repair itself uses `secedit` rather than `Set-Acl` because the key denies WRITE_DAC even to SYSTEM. It writes a UTF-16 `.inf` security template with the correct SDDL, applies it with `/areas REGKEYS`, then verifies at least 8 explicit ACEs are present and throws if not. Placing it before the SQL Server, ODBC, and vcredist installs is required, since those are what fail without it.

## Notes for reviewers

- The one-liner is deliberately kept verbatim from the upstream workaround rather than being reformatted, so it can be diffed against the source. It is not pretty, but it is byte-for-byte the known-good fix minus the Dockerfile `\\` escaping.
- This is a workaround, not a fix. It should be removed once the upstream issue is resolved and the base images ship correct ACLs.
- The build fails fast with `StateRepository ACL repair failed` if the repair does not take, rather than failing later in a confusing way during an installer step.

## Testing

Build an ltsc2019 image and confirm `Repairing StateRepository ACL` / `Success` appears early in the `SetupGeneric1.ps1` step:

```powershell
.\build\build.ps1 `
  -BaseImage 'mcr.microsoft.com/dotnet/framework/runtime:4.8-windowsservercore-ltsc2019' `
  -LtscTag ltsc2019 -FilesOnly $false -Only24 $false -GenericTag '9.9.9.9'
```

Running the same with an ltsc2022 base image should skip the block.